### PR TITLE
feat(post): 게시글 도메인 기초 CRUD API 구현

### DIFF
--- a/back/src/main/java/dev/kyudong/back/common/exception/GlobalExceptionHandler.java
+++ b/back/src/main/java/dev/kyudong/back/common/exception/GlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package dev.kyudong.back.common.exception;
 
+import dev.kyudong.back.post.exception.PostNotFoundException;
 import dev.kyudong.back.user.exception.UserAlreadyExistsException;
 import dev.kyudong.back.user.exception.UserNotFoundException;
 import org.springframework.http.HttpStatus;
@@ -42,5 +43,26 @@ public class GlobalExceptionHandler {
 		problemDetail.setProperty("timestamp", Instant.now());
 		return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(problemDetail);
 	}
+
+	@ExceptionHandler(PostNotFoundException.class)
+	protected ResponseEntity<ProblemDetail> handlePostNotFoundException(PostNotFoundException e) {
+		ProblemDetail problemDetail = ProblemDetail.forStatusAndDetail(HttpStatus.NOT_FOUND, e.getMessage());
+		problemDetail.setTitle("Post Not Found");
+		problemDetail.setStatus(HttpStatus.NOT_FOUND);
+		problemDetail.setDetail(e.getMessage());
+		problemDetail.setProperty("timestamp", Instant.now());
+		return ResponseEntity.status(HttpStatus.NOT_FOUND).body(problemDetail);
+	}
+
+	@ExceptionHandler(InvalidAccessException.class)
+	protected ResponseEntity<ProblemDetail> handleInvalidAccessException(InvalidAccessException e) {
+		ProblemDetail problemDetail = ProblemDetail.forStatusAndDetail(HttpStatus.UNAUTHORIZED, e.getMessage());
+		problemDetail.setTitle("Access Denied");
+		problemDetail.setStatus(HttpStatus.UNAUTHORIZED);
+		problemDetail.setDetail(e.getMessage());
+		problemDetail.setProperty("timestamp", Instant.now());
+		return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(problemDetail);
+	}
+
 
 }

--- a/back/src/main/java/dev/kyudong/back/common/exception/InvalidAccessException.java
+++ b/back/src/main/java/dev/kyudong/back/common/exception/InvalidAccessException.java
@@ -1,0 +1,7 @@
+package dev.kyudong.back.common.exception;
+
+public class InvalidAccessException extends RuntimeException {
+	public InvalidAccessException(String message) {
+		super(message);
+	}
+}

--- a/back/src/main/java/dev/kyudong/back/post/api/PostApi.java
+++ b/back/src/main/java/dev/kyudong/back/post/api/PostApi.java
@@ -1,0 +1,239 @@
+package dev.kyudong.back.post.api;
+
+import dev.kyudong.back.post.api.dto.req.PostCreateReqDto;
+import dev.kyudong.back.post.api.dto.req.PostStatusUpdateReqDto;
+import dev.kyudong.back.post.api.dto.req.PostUpdateReqDto;
+import dev.kyudong.back.post.api.dto.res.PostCreateResDto;
+import dev.kyudong.back.post.api.dto.res.PostDetailResDto;
+import dev.kyudong.back.post.api.dto.res.PostStatusUpdateResDto;
+import dev.kyudong.back.post.api.dto.res.PostUpdateResDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.headers.Header;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.MediaType;
+import org.springframework.http.ProblemDetail;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+
+/**
+ * Post API의 명세를 정의하는 인터페이스입니다.
+ * <p>
+ * 이 인터페이스의 메소드들은 실제 코드에서 직접 호출되지 않지만,
+ * Spring MVC 프레임워크에 의해 런타임 시 동적으로 구현체(Controller)와 연결되어 사용됩니다.
+ * <p>
+ * 따라서 IDE에서 '사용되지 않음(unused)'으로 잘못 분석할 수 있으므로,
+ * {@code @SuppressWarnings("unused")}를 사용하여 관련 경고를 억제합니다.
+ *
+ * @see org.springframework.web.bind.annotation.RestController
+ * @see java.lang.SuppressWarnings
+ */
+@Tag(name = "Post API", description = "게시글 관련 API 명세서")
+public interface PostApi {
+
+	@SuppressWarnings("unused")
+	@Operation(summary = "게시글 조회", description = "게시글 하나를 조회합니다.")
+	@ApiResponses({
+			@ApiResponse(responseCode = "200", description = "게시글 조회 성공",
+					content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+							schema = @Schema(implementation = PostDetailResDto.class),
+							examples = @ExampleObject(value =
+									"""
+									{
+										"id": 1,
+										"userName": "testUser"
+									}
+									"""
+							)
+					)
+			),
+			@ApiResponse(responseCode = "404", description = "존재하지 않는 게시글입니다.",
+					content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+							schema = @Schema(implementation = ProblemDetail.class),
+							examples = @ExampleObject(value =
+									"""
+									{
+										"type": "about:blank",
+										"title": "Post Not Found",
+										"status": 404,
+										"detail": "Post {999} Not Found",
+										"instance": "/api/v1/post/999",
+										"timestamp": "2025-08-16T16:20:22.367368100Z"
+									}
+									"""
+							)
+					)
+			),
+	})
+	ResponseEntity<PostDetailResDto> findPostById(
+			@Parameter(name = "postId", description = "조회할 게시글의 ID", required = true, example = "1")
+			@PathVariable long postId
+	);
+
+	@SuppressWarnings("unused")
+	@Operation(summary = "게시글 생성", description = "게시글을 생성합니다.")
+	@ApiResponses({
+			@ApiResponse(
+					responseCode = "201",
+					description = "게시글 생성 성공",
+					headers = @Header(
+							name = "Location",
+							description = "생성된 게시글 리소스의 URI",
+							schema = @Schema(type = "string", format = "uri"),
+							examples = @ExampleObject(value = "/api/v1/post/1")
+					),
+					content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+							schema = @Schema(implementation = PostCreateReqDto.class),
+							examples = @ExampleObject(value =
+									"""
+									{
+										"userId": 1,
+										"subject": "Subject",
+										"content": "This is Content"
+									}
+									"""
+							)
+					)
+			),
+			@ApiResponse(responseCode = "404", description = "게시글 작성자 조회 실패로 글작성 실패",
+					content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+							schema = @Schema(implementation = ProblemDetail.class),
+							examples = @ExampleObject(value =
+									"""
+									{
+										"type": "about:blank",
+										"title": "User Not Found",
+										"status": 404,
+										"detail": "User {999} Not Found",
+										"instance": "/api/v1/post",
+										"timestamp": "2025-08-16T16:20:57.819701100Z"
+									}
+									"""
+							)
+					)
+			),
+	})
+	ResponseEntity<PostCreateResDto> createUser(@RequestBody PostCreateReqDto request);
+
+	@SuppressWarnings("unused")
+	@Operation(summary = "게시글 수정", description = "게시글을 수정합니다.")
+	@ApiResponses({
+			@ApiResponse(responseCode = "200", description = "게시글 수정에 성공했습니다.",
+					content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+							schema = @Schema(implementation = PostUpdateReqDto.class),
+							examples = @ExampleObject(value =
+									"""
+									{
+										"userId": 1,
+										"subject": "New Subject",
+										"content": "This is Chagne Content"
+									}
+									"""
+							)
+					)
+			),
+			@ApiResponse(responseCode = "404", description = "게시글 조회 실패로 수정 실패",
+					content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+							schema = @Schema(implementation = ProblemDetail.class),
+							examples = @ExampleObject(value =
+									"""
+									{
+										"type": "about:blank",
+										"title": "Post Not Found",
+										"status": 404,
+										"detail": "Post {999} Not Found",
+										"instance": "/api/v1/post/999/status",
+										"timestamp": "2025-08-16T16:21:54.535513500Z"
+									}
+									"""
+							)
+					)
+			),
+			@ApiResponse(responseCode = "401", description = "게시글 작성자의 수정 권한 불가로 수정 실패",
+					content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+							schema = @Schema(implementation = ProblemDetail.class),
+							examples = @ExampleObject(value =
+									"""
+									{
+										"type": "about:blank",
+										"title": "Access Denied",
+										"status": 401,
+										"detail": "User {999} has no permission to update post 23",
+										"instance": "/api/v1/post/23/update",
+										"timestamp": "2025-08-16T16:24:35.784899900Z"
+									}
+									"""
+							)
+					)
+			),
+	})
+	ResponseEntity<PostUpdateResDto> updatePost(
+			@Parameter(name = "postId", description = "수정할 게시글의 ID", required = true, example = "1")
+			@PathVariable long postId,
+			@RequestBody PostUpdateReqDto request
+	);
+
+	@SuppressWarnings("unused")
+	@Operation(summary = "게시글 상태 수정", description = "게시글의 상태를 수정합니다.")
+	@ApiResponses({
+			@ApiResponse(responseCode = "200", description = "게시글의 상태 수정을 성공했습니다.",
+					content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+							schema = @Schema(implementation = PostStatusUpdateReqDto.class),
+							examples = @ExampleObject(value =
+									"""
+									{
+										"userId": 1,
+										"status": "New Subject",
+									}
+									"""
+							)
+					)
+			),
+			@ApiResponse(responseCode = "404", description = "존재하지 않는 게시글입니다.",
+					content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+							schema = @Schema(implementation = ProblemDetail.class),
+							examples = @ExampleObject(value =
+									"""
+									{
+										"type": "about:blank",
+										"title": "Post Not Found",
+										"status": 404,
+										"detail": "Post {999} Not Found",
+										"instance": "/api/v1/post/999/status",
+										"timestamp": "2025-08-16T16:25:26.736754700Z"
+									}
+									"""
+							)
+					)
+			),
+			@ApiResponse(responseCode = "401", description = "게시글 작성자의 수정 권한 불가로 수정 실패",
+					content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+							schema = @Schema(implementation = ProblemDetail.class),
+							examples = @ExampleObject(value =
+									"""
+									{
+										"type": "about:blank",
+										"title": "Access Denied",
+										"status": 401,
+										"detail": "User {999} has no permission to update post status 23",
+										"instance": "/api/v1/post/23/status",
+										"timestamp": "2025-08-16T16:26:08.968567300Z"
+									}
+									"""
+							)
+					)
+			),
+	})
+	ResponseEntity<PostStatusUpdateResDto> updatePostStatus(
+			@Parameter(name = "postId", description = "상태를 수정할 게시글의 ID", required = true, example = "1")
+			@PathVariable long postId,
+			@RequestBody PostStatusUpdateReqDto request
+	);
+
+}

--- a/back/src/main/java/dev/kyudong/back/post/api/PostController.java
+++ b/back/src/main/java/dev/kyudong/back/post/api/PostController.java
@@ -1,0 +1,54 @@
+package dev.kyudong.back.post.api;
+
+import dev.kyudong.back.post.api.dto.req.PostCreateReqDto;
+import dev.kyudong.back.post.api.dto.req.PostStatusUpdateReqDto;
+import dev.kyudong.back.post.api.dto.req.PostUpdateReqDto;
+import dev.kyudong.back.post.api.dto.res.PostCreateResDto;
+import dev.kyudong.back.post.api.dto.res.PostDetailResDto;
+import dev.kyudong.back.post.api.dto.res.PostStatusUpdateResDto;
+import dev.kyudong.back.post.api.dto.res.PostUpdateResDto;
+import dev.kyudong.back.post.service.PostService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
+
+import java.net.URI;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/post")
+public class PostController implements PostApi {
+
+	private final PostService postService;
+
+	@Override
+	@GetMapping("/{postId}")
+	public ResponseEntity<PostDetailResDto> findPostById(@PathVariable long postId) {
+		return ResponseEntity.ok(postService.findPostById(postId));
+	}
+
+	@Override
+	@PostMapping
+	public ResponseEntity<PostCreateResDto> createUser(PostCreateReqDto request) {
+		PostCreateResDto postCreateResDto = postService.createPost(request);
+		URI uri = ServletUriComponentsBuilder.fromCurrentRequest()
+				.path("/{id}")
+				.buildAndExpand(postCreateResDto.postId())
+				.toUri();
+		return ResponseEntity.created(uri).body(postCreateResDto);
+	}
+
+	@Override
+	@PatchMapping("/{postId}/update")
+	public ResponseEntity<PostUpdateResDto> updatePost(@PathVariable long postId, PostUpdateReqDto request) {
+		return ResponseEntity.ok(postService.updatePost(postId, request));
+	}
+
+	@Override
+	@PatchMapping("/{postId}/status")
+	public ResponseEntity<PostStatusUpdateResDto> updatePostStatus(@PathVariable long postId, PostStatusUpdateReqDto request) {
+		return ResponseEntity.ok(postService.updatePostStatus(postId, request));
+	}
+
+}

--- a/back/src/main/java/dev/kyudong/back/post/api/dto/req/PostCreateReqDto.java
+++ b/back/src/main/java/dev/kyudong/back/post/api/dto/req/PostCreateReqDto.java
@@ -1,0 +1,8 @@
+package dev.kyudong.back.post.api.dto.req;
+
+public record PostCreateReqDto(
+		long userId,
+		String subject,
+		String content
+) {
+}

--- a/back/src/main/java/dev/kyudong/back/post/api/dto/req/PostStatusUpdateReqDto.java
+++ b/back/src/main/java/dev/kyudong/back/post/api/dto/req/PostStatusUpdateReqDto.java
@@ -1,0 +1,9 @@
+package dev.kyudong.back.post.api.dto.req;
+
+import dev.kyudong.back.post.domain.PostStatus;
+
+public record PostStatusUpdateReqDto(
+		long userId,
+		PostStatus status
+) {
+}

--- a/back/src/main/java/dev/kyudong/back/post/api/dto/req/PostUpdateReqDto.java
+++ b/back/src/main/java/dev/kyudong/back/post/api/dto/req/PostUpdateReqDto.java
@@ -1,0 +1,8 @@
+package dev.kyudong.back.post.api.dto.req;
+
+public record PostUpdateReqDto(
+		long userId,
+		String subject,
+		String content
+) {
+}

--- a/back/src/main/java/dev/kyudong/back/post/api/dto/res/PostCreateResDto.java
+++ b/back/src/main/java/dev/kyudong/back/post/api/dto/res/PostCreateResDto.java
@@ -1,0 +1,22 @@
+package dev.kyudong.back.post.api.dto.res;
+
+import dev.kyudong.back.post.domain.Post;
+
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+
+public record PostCreateResDto(
+		long postId,
+		String subject,
+		String content,
+		LocalDateTime createdAt,
+		LocalDateTime modifiedAt
+) {
+	public static PostCreateResDto from(Post post) {
+		return new PostCreateResDto(
+				post.getId(), post.getSubject(), post.getContent(),
+				LocalDateTime.ofInstant(post.getCreatedAt(), ZoneOffset.UTC),
+				LocalDateTime.ofInstant(post.getModifiedAt(), ZoneOffset.UTC)
+		);
+	}
+}

--- a/back/src/main/java/dev/kyudong/back/post/api/dto/res/PostDetailResDto.java
+++ b/back/src/main/java/dev/kyudong/back/post/api/dto/res/PostDetailResDto.java
@@ -1,0 +1,25 @@
+package dev.kyudong.back.post.api.dto.res;
+
+import dev.kyudong.back.post.domain.Post;
+import dev.kyudong.back.post.domain.PostStatus;
+
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+
+public record PostDetailResDto(
+		long postId,
+		long userId,
+		String subject,
+		String content,
+		PostStatus status,
+		LocalDateTime createdAt,
+		LocalDateTime modifiedAt
+) {
+	public static PostDetailResDto from(Post post) {
+		return new PostDetailResDto(
+				post.getId(), post.getUser().getId(), post.getSubject(), post.getContent(), post.getStatus(),
+				LocalDateTime.ofInstant(post.getCreatedAt(), ZoneOffset.UTC),
+				LocalDateTime.ofInstant(post.getModifiedAt(), ZoneOffset.UTC)
+		);
+	}
+}

--- a/back/src/main/java/dev/kyudong/back/post/api/dto/res/PostStatusUpdateResDto.java
+++ b/back/src/main/java/dev/kyudong/back/post/api/dto/res/PostStatusUpdateResDto.java
@@ -1,0 +1,15 @@
+package dev.kyudong.back.post.api.dto.res;
+
+import dev.kyudong.back.post.domain.Post;
+import dev.kyudong.back.post.domain.PostStatus;
+
+public record PostStatusUpdateResDto(
+		long postId,
+		PostStatus status
+) {
+	public static PostStatusUpdateResDto from(Post post) {
+		return new PostStatusUpdateResDto(
+				post.getId(), post.getStatus()
+		);
+	}
+}

--- a/back/src/main/java/dev/kyudong/back/post/api/dto/res/PostUpdateResDto.java
+++ b/back/src/main/java/dev/kyudong/back/post/api/dto/res/PostUpdateResDto.java
@@ -1,0 +1,22 @@
+package dev.kyudong.back.post.api.dto.res;
+
+import dev.kyudong.back.post.domain.Post;
+
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+
+public record PostUpdateResDto(
+		long postId,
+		String subject,
+		String content,
+		LocalDateTime createdAt,
+		LocalDateTime modifiedAt
+) {
+	public static PostUpdateResDto from(Post post) {
+		return new PostUpdateResDto(
+				post.getId(), post.getSubject(), post.getContent(),
+				LocalDateTime.ofInstant(post.getCreatedAt(), ZoneOffset.UTC),
+				LocalDateTime.ofInstant(post.getModifiedAt(), ZoneOffset.UTC)
+		);
+	}
+}

--- a/back/src/main/java/dev/kyudong/back/post/domain/Post.java
+++ b/back/src/main/java/dev/kyudong/back/post/domain/Post.java
@@ -1,0 +1,103 @@
+package dev.kyudong.back.post.domain;
+
+import dev.kyudong.back.common.exception.InvalidInputException;
+import dev.kyudong.back.user.domain.User;
+import jakarta.persistence.*;
+import lombok.*;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+import org.springframework.util.StringUtils;
+
+import java.time.Instant;
+
+@Entity
+@Getter
+@ToString
+@Table(name = "POST")
+@EntityListeners(AuditingEntityListener.class)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Post {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "ID", updatable = false)
+	private Long id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "USER_ID", nullable = false)
+	private User user;
+
+	@Column(name = "SUBJECT", length = 100, nullable = false)
+	private String subject;
+
+	@Lob
+	@Column(name = "CONTENT", nullable = false)
+	private String content;
+
+	@CreatedDate
+	@Column(name = "CREATED_AT", updatable = false)
+	private Instant createdAt;
+
+	@LastModifiedDate
+	@Column(name = "UPDATED_AT")
+	private Instant modifiedAt;
+
+	@Enumerated(EnumType.STRING)
+	@Column(name = "STATUS", nullable = false)
+	private PostStatus status;
+
+	@Builder
+	public Post(String subject, String content) {
+		validSubject(subject);
+		validContent(content);
+		Instant now = Instant.now();
+		this.subject = subject;
+		this.content = content;
+		this.createdAt = now;
+		this.modifiedAt = now;
+		this.status = PostStatus.NORMAL;
+	}
+
+	public void updateSubject(String subject) {
+		validSubject(subject);
+		this.subject = subject;
+	}
+
+	private void validSubject(String subject) {
+		if (!StringUtils.hasText(subject)) {
+			throw new InvalidInputException("Subject must not be null");
+		}
+		if (subject.length() > 100) {
+			throw new InvalidInputException("Subject cannot be longer than 100 characters.");
+		}
+	}
+
+	public void updateContent(String content) {
+		validContent(content);
+		this.content = content;
+	}
+
+	private void validContent(String content) {
+		if (!StringUtils.hasText(content)) {
+			throw new InvalidInputException("Content must not be null");
+		}
+	}
+
+	public void delete() {
+		this.status = PostStatus.DELETED;
+	}
+
+	public void restore() {
+		this.status = PostStatus.NORMAL;
+	}
+
+	/**
+	 * addPost를 이용한 호출을 권장합니다.
+	 * @param user 게시글 소유자.
+	 */
+	public void associateUser(User user) {
+		this.user = user;
+	}
+
+}

--- a/back/src/main/java/dev/kyudong/back/post/domain/PostStatus.java
+++ b/back/src/main/java/dev/kyudong/back/post/domain/PostStatus.java
@@ -1,0 +1,8 @@
+package dev.kyudong.back.post.domain;
+
+public enum PostStatus {
+
+	NORMAL,		// 정상
+	DELETED,	// 삭제
+
+}

--- a/back/src/main/java/dev/kyudong/back/post/exception/PostNotFoundException.java
+++ b/back/src/main/java/dev/kyudong/back/post/exception/PostNotFoundException.java
@@ -1,0 +1,7 @@
+package dev.kyudong.back.post.exception;
+
+public class PostNotFoundException extends RuntimeException {
+	public PostNotFoundException(String message) {
+		super(message);
+	}
+}

--- a/back/src/main/java/dev/kyudong/back/post/repository/PostRepository.java
+++ b/back/src/main/java/dev/kyudong/back/post/repository/PostRepository.java
@@ -1,0 +1,9 @@
+package dev.kyudong.back.post.repository;
+
+import dev.kyudong.back.post.domain.Post;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PostRepository extends JpaRepository<Post, Long> {
+
+
+}

--- a/back/src/main/java/dev/kyudong/back/post/service/PostService.java
+++ b/back/src/main/java/dev/kyudong/back/post/service/PostService.java
@@ -1,0 +1,121 @@
+package dev.kyudong.back.post.service;
+
+import dev.kyudong.back.common.exception.InvalidAccessException;
+import dev.kyudong.back.common.exception.InvalidInputException;
+import dev.kyudong.back.post.api.dto.req.PostCreateReqDto;
+import dev.kyudong.back.post.api.dto.req.PostStatusUpdateReqDto;
+import dev.kyudong.back.post.api.dto.req.PostUpdateReqDto;
+import dev.kyudong.back.post.api.dto.res.PostCreateResDto;
+import dev.kyudong.back.post.api.dto.res.PostStatusUpdateResDto;
+import dev.kyudong.back.post.api.dto.res.PostDetailResDto;
+import dev.kyudong.back.post.api.dto.res.PostUpdateResDto;
+import dev.kyudong.back.post.domain.Post;
+import dev.kyudong.back.post.exception.PostNotFoundException;
+import dev.kyudong.back.post.repository.PostRepository;
+import dev.kyudong.back.user.domain.User;
+import dev.kyudong.back.user.exception.UserNotFoundException;
+import dev.kyudong.back.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class PostService {
+
+	private final PostRepository postRepository;
+	private final UserRepository userRepository;
+
+	@Transactional(readOnly = true)
+	public PostDetailResDto findPostById(long postId) {
+		log.debug("게시글 조회 요청 시작: postId: {}", postId);
+
+		Post post = postRepository.findById(postId).orElseThrow(() -> {
+					log.warn("게시글 조회 실패 - 존재하지 않는 게시글 : postId: {}", postId);
+					return new PostNotFoundException("Post {" + postId + "} Not Found");
+				});
+
+		log.info("게시글 조회 요청 성공: postId: {}", postId);
+		return PostDetailResDto.from(post);
+	}
+
+	@Transactional
+	public PostCreateResDto createPost(PostCreateReqDto request) {
+		log.debug("게시글 생성 요청 시작: userId: {}, subject: {}", request.userId(), request.subject());
+
+		User user = userRepository.findById(request.userId())
+				.orElseThrow(() -> {
+					log.warn("사용자 조회 실패 - 존재하지 않는 사용자 : userId: {}", request.userId());
+					return new UserNotFoundException("User {" + request.userId() + "} Not Found");
+				});
+
+		Post newPost = Post.builder()
+				.subject(request.subject())
+				.content(request.content())
+				.build();
+		user.addPost(newPost);
+		Post savedPost = postRepository.save(newPost);
+
+		log.info("게시글 수정 요청 성공: userId: {}, postId: {}", savedPost.getUser().getId(), savedPost.getId());
+		return PostCreateResDto.from(savedPost);
+	}
+
+	@Transactional
+	public PostUpdateResDto updatePost(long postId, PostUpdateReqDto request) {
+		log.debug("게시글 수정 요청 시작: userId: {}, postId: {}", request.userId(), postId);
+
+		Post post = postRepository.findById(postId)
+				.orElseThrow(() -> {
+					log.warn("게시글 수정 실패 - 존재하지 않는 게시글 : postId: {}", postId);
+					return new PostNotFoundException("Post {" + postId + "} Not Found");
+				});
+
+		if (!post.getUser().getId().equals(request.userId())) {
+			log.warn("게시글 수정 실패 - 권한 없음 : userId: {}, postId: {}", request.userId(), postId);
+			throw new InvalidAccessException("User {" + request.userId() + "} has no permission to update post " + postId);
+		}
+
+		if (StringUtils.hasText(request.subject())) {
+			post.updateSubject(request.subject());
+		}
+
+		if (StringUtils.hasText(request.content())) {
+			post.updateContent(request.content());
+		}
+
+		log.info("게시글 수정 요청 성공: userId: {}, postId: {}", post.getUser().getId(), post.getId());
+		return PostUpdateResDto.from(post);
+	}
+
+	@Transactional
+	public PostStatusUpdateResDto updatePostStatus(long postId, PostStatusUpdateReqDto request) {
+		log.debug("게시글 상태 수정 요청 시작: userId: {}, postId: {}", request.userId(), postId);
+
+		Post post = postRepository.findById(postId)
+				.orElseThrow(() -> {
+					log.warn("게시글 상태 수정 실패 - 존재하지 않는 게시글 : postId: {}", postId);
+					return new PostNotFoundException("Post {" + postId + "} Not Found");
+				});
+
+		if (!post.getUser().getId().equals(request.userId())) {
+			log.warn("게시글 상태 수정 실패 - 권한 없음 : userId: {}, postId: {}", request.userId(), postId);
+			throw new InvalidAccessException("User {" + request.userId() + "} has no permission to update post status " + postId);
+		}
+
+		switch (request.status()) {
+			case NORMAL -> post. restore();
+			case DELETED -> post.delete();
+			default -> {
+				log.warn("응답할 수 없는 게시글 상태 요청 : postId: {}, status: {}", post, request.status().name());
+				throw new InvalidInputException("PostStatus Cant not be update");
+			}
+		}
+
+		log.info("게시글 상태 수정 요청 성공: userId: {}, postId: {}, status: {}", post.getUser().getId(), post.getId(), post.getStatus().name());
+		return PostStatusUpdateResDto.from(post);
+	}
+
+}

--- a/back/src/main/java/dev/kyudong/back/user/domain/User.java
+++ b/back/src/main/java/dev/kyudong/back/user/domain/User.java
@@ -1,6 +1,7 @@
 package dev.kyudong.back.user.domain;
 
 import dev.kyudong.back.common.exception.InvalidInputException;
+import dev.kyudong.back.post.domain.Post;
 import jakarta.persistence.*;
 import lombok.*;
 import org.springframework.data.annotation.CreatedDate;
@@ -8,6 +9,8 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 import org.springframework.util.StringUtils;
 
 import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Getter
@@ -35,6 +38,9 @@ public class User {
 	@CreatedDate
 	@Column(name = "CREATED_AT", updatable = false)
 	private Instant createdAt;
+
+	@OneToMany(fetch = FetchType.LAZY, mappedBy = "user")
+	private final List<Post> postList = new ArrayList<>();
 
 	@Builder
 	public User(String userName, String passWord) {
@@ -67,6 +73,11 @@ public class User {
 
 	public void deleteUser() {
 		this.status = UserStatus.DELETED;
+	}
+
+	public void addPost(@NonNull Post post) {
+		this.postList.add(post);
+		post.associateUser(this);
 	}
 
 }

--- a/back/src/test/java/dev/kyudong/back/post/PostControllerTests.java
+++ b/back/src/test/java/dev/kyudong/back/post/PostControllerTests.java
@@ -1,0 +1,200 @@
+package dev.kyudong.back.post;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import dev.kyudong.back.common.exception.InvalidAccessException;
+import dev.kyudong.back.post.api.PostController;
+import dev.kyudong.back.post.api.dto.req.PostCreateReqDto;
+import dev.kyudong.back.post.api.dto.req.PostStatusUpdateReqDto;
+import dev.kyudong.back.post.api.dto.req.PostUpdateReqDto;
+import dev.kyudong.back.post.api.dto.res.PostCreateResDto;
+import dev.kyudong.back.post.api.dto.res.PostDetailResDto;
+import dev.kyudong.back.post.api.dto.res.PostStatusUpdateResDto;
+import dev.kyudong.back.post.api.dto.res.PostUpdateResDto;
+import dev.kyudong.back.post.domain.PostStatus;
+import dev.kyudong.back.post.exception.PostNotFoundException;
+import dev.kyudong.back.post.service.PostService;
+import dev.kyudong.back.user.exception.UserNotFoundException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.MediaType;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDateTime;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(PostController.class)
+public class PostControllerTests {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Autowired
+	private ObjectMapper objectMapper;
+
+	@SuppressWarnings("unused")
+	@MockitoBean
+	private PostService postService;
+
+	@Test
+	@DisplayName("게시글 조회 API - 성공")
+	void findPostByIdApi_success() throws Exception {
+		// given
+		long postId = 1L;
+		PostDetailResDto response = new PostDetailResDto(postId, 1L, "Test", "Hello World!", PostStatus.NORMAL, LocalDateTime.now(), LocalDateTime.now());
+		when(postService.findPostById(eq(postId))).thenReturn(response);
+
+		// when & then
+		mockMvc.perform(get("/api/v1/post/{postId}", postId))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.postId").value(postId))
+				.andExpect(jsonPath("$.subject").value("Test"))
+				.andExpect(jsonPath("$.content").value("Hello World!"))
+				.andDo(print());
+	}
+
+	@Test
+	@DisplayName("게시글 조회 API - 실패 : 요청한 게시글이 존재하지 않음.")
+	void findPostByIdApi_fail() throws Exception {
+		// given
+		long postId = 999L;
+		when(postService.findPostById(eq(postId)))
+				.thenThrow(new PostNotFoundException("Post {" + postId + "} Not Found"));
+
+		// when & then
+		mockMvc.perform(get("/api/v1/post/{postId}", postId))
+				.andExpect(status().isNotFound())
+				.andExpect(jsonPath("$.title").value("Post Not Found"))
+				.andExpect(jsonPath("$.status").value(404))
+				.andExpect(jsonPath("$.detail").value("Post {" + postId + "} Not Found"))
+				.andDo(print());
+	}
+
+	@Test
+	@DisplayName("게시글 생성 API - 성공")
+	void createPostApi_success() throws Exception {
+		// given
+		long postId = 1L;
+		PostCreateReqDto request = new PostCreateReqDto(1L, "Test", "Hello World!");
+		PostCreateResDto response = new PostCreateResDto(postId, "Test", "Hello World!", LocalDateTime.now(), LocalDateTime.now());
+		when(postService.createPost(any(PostCreateReqDto.class))).thenReturn(response);
+
+		// when & then
+		mockMvc.perform(post("/api/v1/post")
+						.contentType(MediaType.APPLICATION_JSON.toString())
+						.content(objectMapper.writeValueAsString(request)))
+				.andExpect(status().isCreated())
+				.andExpect(jsonPath("$.postId").value(postId))
+				.andExpect(jsonPath("$.subject").value("Test"))
+				.andExpect(jsonPath("$.content").value("Hello World!"))
+				.andDo(print());
+	}
+
+	@Test
+	@DisplayName("게시글 생성 API - 실패 : 작성자의 정보가 조회가 안됨")
+	void createPostApi_fail() throws Exception {
+		// given
+		PostCreateReqDto request = new PostCreateReqDto(1L, "Test", "Hello World!");
+		when(postService.createPost(any(PostCreateReqDto.class)))
+				.thenThrow(new UserNotFoundException("User {" + request.userId() + "} Not Found"));
+
+		// when & then
+		mockMvc.perform(post("/api/v1/post")
+						.contentType(MediaType.APPLICATION_JSON.toString())
+						.content(objectMapper.writeValueAsString(request)))
+				.andExpect(status().isNotFound())
+				.andExpect(jsonPath("$.title").value("User Not Found"))
+				.andExpect(jsonPath("$.status").value(404))
+				.andExpect(jsonPath("$.detail").value("User {" + request.userId() + "} Not Found"))
+				.andDo(print());
+	}
+
+	@Test
+	@DisplayName("게시글 수정 API - 성공")
+	void updatePostApi_success() throws Exception {
+		// given
+		long postId = 1L;
+		PostUpdateReqDto request = new PostUpdateReqDto(1L, "Test", "Hello World!");
+		PostUpdateResDto response = new PostUpdateResDto(postId, "Test", "Hello World!", LocalDateTime.now(), LocalDateTime.now());
+		when(postService.updatePost(eq(postId), any(PostUpdateReqDto.class))).thenReturn(response);
+
+		// when & then
+		mockMvc.perform(patch("/api/v1/post/{postId}/update", postId)
+						.contentType(MediaType.APPLICATION_JSON.toString())
+						.content(objectMapper.writeValueAsString(request)))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.postId").value(postId))
+				.andExpect(jsonPath("$.subject").value("Test"))
+				.andExpect(jsonPath("$.content").value("Hello World!"))
+				.andDo(print());
+	}
+
+	@Test
+	@DisplayName("게시글 수정 API - 실패 : 게시글 수정 권한 없음")
+	void updatePostApi_fail() throws Exception {
+		// given
+		long postId = 1L;
+		PostUpdateReqDto request = new PostUpdateReqDto(1L, "Test", "Hello World!");
+		when(postService.updatePost(eq(postId), any(PostUpdateReqDto.class)))
+				.thenThrow(new InvalidAccessException("User {" + request.userId() + "} has no permission to update post " + postId));
+
+		// when & then
+		mockMvc.perform(patch("/api/v1/post/{postId}/update", postId)
+						.contentType(MediaType.APPLICATION_JSON.toString())
+						.content(objectMapper.writeValueAsString(request)))
+				.andExpect(status().isUnauthorized())
+				.andExpect(jsonPath("$.title").value("Access Denied"))
+				.andExpect(jsonPath("$.status").value(401))
+				.andExpect(jsonPath("$.detail").value("User {" + request.userId() + "} has no permission to update post " + postId))
+				.andDo(print());
+	}
+
+	@Test
+	@DisplayName("게시글 상태 수정 API")
+	void updatePostStatusApi_success() throws Exception {
+		// given
+		long postId = 1L;
+		PostStatusUpdateReqDto request = new PostStatusUpdateReqDto(1L, PostStatus.DELETED);
+		PostStatusUpdateResDto response = new PostStatusUpdateResDto(postId, PostStatus.DELETED);
+		when(postService.updatePostStatus(eq(postId), any(PostStatusUpdateReqDto.class))).thenReturn(response);
+
+		// when & then
+		mockMvc.perform(patch("/api/v1/post/{postId}/status", postId)
+						.contentType(MediaType.APPLICATION_JSON.toString())
+						.content(objectMapper.writeValueAsString(request)))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.postId").value(1L))
+				.andExpect(jsonPath("$.status").value(PostStatus.DELETED.name()))
+				.andDo(print());
+	}
+
+	@Test
+	@DisplayName("게시글 상태 수정 API - 실패 : 게시글 수정 권한 없음")
+	void updatePostStatusApi_fail() throws Exception {
+		// given
+		long postId = 1L;
+		PostStatusUpdateReqDto request = new PostStatusUpdateReqDto(1L, PostStatus.DELETED);
+		when(postService.updatePostStatus(eq(postId), any(PostStatusUpdateReqDto.class)))
+				.thenThrow(new InvalidAccessException("User {" + request.userId() + "} has no permission to update post status " + postId));
+
+		// when & then
+		mockMvc.perform(patch("/api/v1/post/{postId}/status", postId)
+						.contentType(MediaType.APPLICATION_JSON.toString())
+						.content(objectMapper.writeValueAsString(request)))
+				.andExpect(status().isUnauthorized())
+				.andExpect(jsonPath("$.title").value("Access Denied"))
+				.andExpect(jsonPath("$.status").value(401))
+				.andExpect(jsonPath("$.detail").value("User {" + request.userId() + "} has no permission to update post status " + postId))
+				.andDo(print());
+	}
+
+}

--- a/back/src/test/java/dev/kyudong/back/post/PostIntegrationTests.java
+++ b/back/src/test/java/dev/kyudong/back/post/PostIntegrationTests.java
@@ -1,0 +1,160 @@
+package dev.kyudong.back.post;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import dev.kyudong.back.post.api.dto.req.PostCreateReqDto;
+import dev.kyudong.back.post.api.dto.req.PostStatusUpdateReqDto;
+import dev.kyudong.back.post.api.dto.req.PostUpdateReqDto;
+import dev.kyudong.back.post.api.dto.res.PostCreateResDto;
+import dev.kyudong.back.post.api.dto.res.PostUpdateResDto;
+import dev.kyudong.back.post.domain.Post;
+import dev.kyudong.back.post.domain.PostStatus;
+import dev.kyudong.back.post.repository.PostRepository;
+import dev.kyudong.back.user.domain.User;
+import dev.kyudong.back.user.repository.UserRepository;
+import org.hamcrest.CoreMatchers;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.MediaType;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@Transactional
+@SpringBootTest
+@AutoConfigureMockMvc
+public class PostIntegrationTests {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Autowired
+	private ObjectMapper objectMapper;
+
+	@Autowired
+	private PostRepository postRepository;
+
+	@Autowired
+	private UserRepository userRepository;
+
+	private User createTestUser() {
+		return userRepository.save(new User("testUser", "password1234"));
+	}
+
+	@Test
+	@DisplayName("게시글 조회 API")
+	void findPostById() throws Exception {
+		// given
+		User user = createTestUser();
+		Post newPost = Post.builder()
+				.subject("Test")
+				.content("Hello World!")
+				.build();
+		user.addPost(newPost);
+		Post savedPost = postRepository.save(newPost);
+		long postId = savedPost.getId();
+
+		// when & then
+		mockMvc.perform(get("/api/v1/post/{postId}", postId))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.postId").value(postId))
+				.andExpect(jsonPath("$.subject").value("Test"))
+				.andExpect(jsonPath("$.content").value("Hello World!"))
+				.andDo(print());
+	}
+
+	@Test
+	@DisplayName("게시글 생성 API")
+	void createPost() throws Exception {
+		// given
+		User user = createTestUser();
+		PostCreateReqDto request = new PostCreateReqDto(user.getId(), "Test", "Hello Post!");
+
+		// when
+		MvcResult result = mockMvc.perform(post("/api/v1/post")
+							.contentType(MediaType.APPLICATION_JSON.toString())
+							.content(objectMapper.writeValueAsString(request)))
+						.andExpect(status().isCreated())
+						.andExpect(header().exists("Location"))
+						.andExpect(header().string("Location", CoreMatchers.containsString("/api/v1/post/")))
+						.andDo(print())
+						.andReturn();
+
+		// then
+		String responseBody = result.getResponse().getContentAsString();
+		PostCreateResDto response = objectMapper.readValue(responseBody, PostCreateResDto.class);
+		assertThat(response).isNotNull();
+		assertThat(response.subject()).isEqualTo(request.subject());
+		assertThat(response.content()).isEqualTo(request.content());
+
+		Optional<Post> optionalPost = postRepository.findById(response.postId());
+		assertThat(optionalPost).isPresent();
+
+		Post post = optionalPost.get();
+		assertThat(post.getUser().getId()).isEqualTo(user.getId());
+		assertThat(post.getId()).isEqualTo(response.postId());
+	}
+
+	@Test
+	@DisplayName("게시글 수정 API")
+	void updatePost() throws Exception {
+		// given
+		User user = createTestUser();
+		Post post = Post.builder()
+				.subject("Test")
+				.content("Hello World!")
+				.build();
+		user.addPost(post);
+		Post savedPost = postRepository.save(post);
+		PostUpdateReqDto request = new PostUpdateReqDto(user.getId(), "Test", "Hello Java!");
+
+		// when
+		MvcResult result = mockMvc.perform(patch("/api/v1/post/{postId}/update", savedPost.getId())
+							.contentType(MediaType.APPLICATION_JSON.toString())
+							.content(objectMapper.writeValueAsString(request)))
+						.andExpect(status().isOk())
+						.andDo(print())
+						.andReturn();
+
+		// then
+		String responseBody = result.getResponse().getContentAsString();
+		PostUpdateResDto response = objectMapper.readValue(responseBody, PostUpdateResDto.class);
+		assertThat(response).isNotNull();
+		assertThat(response.subject()).isEqualTo(request.subject());
+		assertThat(response.content()).isNotEqualTo("Hello World!");
+	}
+
+	@Test
+	@DisplayName("게시글 상태 수정 API")
+	void updatePostStatus() throws Exception {
+		// given
+		User user = createTestUser();
+		Post newPost = Post.builder()
+				.subject("Test")
+				.content("Hello World!!")
+				.build();
+		user.addPost(newPost);
+		Post savedPost = postRepository.save(newPost);
+		PostStatusUpdateReqDto request = new PostStatusUpdateReqDto(user.getId(), PostStatus.DELETED);
+
+		// when & then
+		mockMvc.perform(patch("/api/v1/post/{postId}/status", savedPost.getId())
+							.contentType(MediaType.APPLICATION_JSON.toString())
+							.content(objectMapper.writeValueAsString(request)))
+					.andExpect(status().isOk())
+					.andExpect(jsonPath("$.postId").value(savedPost.getId()))
+					.andExpect(jsonPath("$.status").value(PostStatus.DELETED.name()))
+					.andDo(print())
+					.andReturn();
+	}
+
+}

--- a/back/src/test/java/dev/kyudong/back/post/PostServiceTests.java
+++ b/back/src/test/java/dev/kyudong/back/post/PostServiceTests.java
@@ -1,0 +1,275 @@
+package dev.kyudong.back.post;
+
+import dev.kyudong.back.common.exception.InvalidAccessException;
+import dev.kyudong.back.common.exception.InvalidInputException;
+import dev.kyudong.back.post.api.dto.req.PostCreateReqDto;
+import dev.kyudong.back.post.api.dto.req.PostStatusUpdateReqDto;
+import dev.kyudong.back.post.api.dto.req.PostUpdateReqDto;
+import dev.kyudong.back.post.api.dto.res.PostCreateResDto;
+import dev.kyudong.back.post.api.dto.res.PostStatusUpdateResDto;
+import dev.kyudong.back.post.api.dto.res.PostDetailResDto;
+import dev.kyudong.back.post.api.dto.res.PostUpdateResDto;
+import dev.kyudong.back.post.domain.Post;
+import dev.kyudong.back.post.domain.PostStatus;
+import dev.kyudong.back.post.exception.PostNotFoundException;
+import dev.kyudong.back.post.repository.PostRepository;
+import dev.kyudong.back.post.service.PostService;
+import dev.kyudong.back.user.domain.User;
+import dev.kyudong.back.user.repository.UserRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class PostServiceTests {
+
+	@Mock
+	private PostRepository postRepository;
+
+	@Mock
+	private UserRepository userRepository;
+
+	@InjectMocks
+	private PostService postService;
+
+	private static User makeMockUser() {
+		User mockUser = new User("userName", "passWord");
+		ReflectionTestUtils.setField(mockUser, "id", 1L);
+		return mockUser;
+	}
+
+	private static Post makeMockPost(User mockUser) {
+		Post mockPost = Post.builder()
+				.subject("subject")
+				.content("content")
+				.build();
+		ReflectionTestUtils.setField(mockPost, "id", 1L);
+		ReflectionTestUtils.setField(mockPost, "user", mockUser);
+		return mockPost;
+	}
+
+	private static Post makeMockPost(Long postId, User mockUser) {
+		Post mockPost = Post.builder()
+				.subject("subject")
+				.content("content")
+				.build();
+		ReflectionTestUtils.setField(mockPost, "id", postId);
+		ReflectionTestUtils.setField(mockPost, "user", mockUser);
+		return mockPost;
+	}
+
+	@Test
+	@DisplayName("게시글 생성 - 성공")
+	void createPost_success() {
+		// given
+		User mockUser = makeMockUser();
+		when(userRepository.findById(eq(mockUser.getId()))).thenReturn(Optional.of(mockUser));
+
+		PostCreateReqDto request = new PostCreateReqDto(mockUser.getId(), "subject", "content");
+		Post mockPost = makeMockPost(mockUser);
+		when(postRepository.save(any(Post.class))).thenReturn(mockPost);
+
+		// when
+		PostCreateResDto response = postService.createPost(request);
+
+		// then
+		assertThat(response).isNotNull();
+		assertThat(response.postId()).isEqualTo(mockPost.getId());
+		assertThat(response.subject()).isEqualTo("subject");
+		assertThat(response.content()).isEqualTo("content");
+
+		// 게시글 반영 확인
+		assertThat(mockUser.getPostList()).isNotEmpty();
+		assertThat(mockUser.getPostList()).hasSize(1);
+		assertThat(mockUser.getPostList().get(0)).isEqualTo(mockPost);
+		verify(postRepository, times(1)).save(any(Post.class));
+	}
+
+	// 게시글 제목 요청에 사용
+	private static Stream<Arguments> provideInvalidSubject() {
+		return Stream.of(
+				Arguments.of((String) null),       		// 1. null
+				Arguments.of(""),          // 2. 빈 문자열 ""
+				Arguments.of(" "),         // 3. 공백 문자 " "
+				Arguments.of("a".repeat(101))    // 4. 101자 문자열
+		);
+	}
+
+	@ParameterizedTest
+	@DisplayName("게시글 생성 - 실패 : 유효하지 않는 제목")
+	@MethodSource("provideInvalidSubject")
+	void createPost_fail_invalidSubject(String invalidSubject) {
+		// given
+		User mockUser = makeMockUser();
+		when(userRepository.findById(eq(mockUser.getId()))).thenReturn(Optional.of(mockUser));
+		PostCreateReqDto request = new PostCreateReqDto(mockUser.getId(), invalidSubject, "content");
+
+		// when & then
+		assertThatThrownBy(() -> postService.createPost(request))
+				.isInstanceOf(InvalidInputException.class)
+				.hasMessageContaining("Subject");
+		verify(postRepository, never()).save(any(Post.class));
+	}
+
+	// 게시글 본문 요청에 사용
+	private static Stream<Arguments> provideInvalidContent() {
+		return Stream.of(
+				Arguments.of((String) null),       		// 1. null
+				Arguments.of("")          // 2. 빈 문자열 ""
+		);
+	}
+
+	@ParameterizedTest
+	@DisplayName("게시글 생성 - 실패 : 유효하지 않는 본문")
+	@MethodSource("provideInvalidContent")
+	void createPost_fail_invalidContent(String invalidContent) {
+		// given
+		User mockUser = makeMockUser();
+		when(userRepository.findById(eq(mockUser.getId()))).thenReturn(Optional.of(mockUser));
+		PostCreateReqDto request = new PostCreateReqDto(mockUser.getId(), "subject", invalidContent);
+
+		// when & then
+		assertThatThrownBy(() -> postService.createPost(request))
+				.isInstanceOf(InvalidInputException.class)
+				.hasMessageContaining("Content");
+		verify(postRepository, never()).save(any(Post.class));
+	}
+
+	@Test
+	@DisplayName("게시글 수정 - 성공")
+	void updatePost_success() {
+		// given
+		User mockUser = makeMockUser();
+		long postId = 1L;
+		PostUpdateReqDto request = new PostUpdateReqDto(mockUser.getId(), "newSubject", "newContent");
+		Post mockPost = makeMockPost(postId, mockUser);
+		when(postRepository.findById(eq(postId))).thenReturn(Optional.of(mockPost));
+
+		// when
+		PostUpdateResDto response = postService.updatePost(postId, request);
+
+		// then
+		assertThat(response).isNotNull();
+		assertThat(response.postId()).isEqualTo(postId);
+		assertThat(response.subject()).isEqualTo("newSubject");
+		assertThat(response.content()).isEqualTo("newContent");
+	}
+
+	@Test
+	@DisplayName("게시글 수정 - 실패 : 존재하지 않는 게시글")
+	void updatePost_fail_postNotFound() {
+		// given
+		User mockUser = makeMockUser();
+		long postId = 1L;
+		PostUpdateReqDto request = new PostUpdateReqDto(mockUser.getId(), "newSubject", "newContent");
+		when(postRepository.findById(eq(postId))).thenReturn(Optional.empty());
+
+		// when & then
+		assertThatThrownBy(() -> postService.updatePost(postId, request))
+				.isInstanceOf(PostNotFoundException.class)
+				.hasMessage("Post {" + postId + "} Not Found");
+		verify(postRepository, times(1)).findById(postId);
+	}
+
+	@Test
+	@DisplayName("게시글 수정 - 실패 : 게시글 수정자 권한 없음")
+	void updatePost_fail_invalidAccess() {
+		// given
+		User mockUser = makeMockUser();
+		long postId = 1L;
+		PostUpdateReqDto request = new PostUpdateReqDto(2L, "newSubject", "newContent");
+		Post mockPost = makeMockPost(postId, mockUser);
+		when(postRepository.findById(eq(postId))).thenReturn(Optional.of(mockPost));
+
+		// when & then
+		assertThatThrownBy(() -> postService.updatePost(postId, request))
+				.isInstanceOf(InvalidAccessException.class)
+				.hasMessage("User {" + request.userId() + "} has no permission to update post " + postId);
+	}
+
+	@Test
+	@DisplayName("게시글 상태 변경 - 성공")
+	void updatePostStatus_success() {
+		// given
+		User mockUser = makeMockUser();
+		long postId = 1L;
+		PostStatusUpdateReqDto request = new PostStatusUpdateReqDto(mockUser.getId(), PostStatus.DELETED);
+		Post mockPost = makeMockPost(postId, mockUser);
+		when(postRepository.findById(eq(postId))).thenReturn(Optional.of(mockPost));
+
+		// when
+		PostStatusUpdateResDto response = postService.updatePostStatus(postId, request);
+
+		// then
+		assertThat(response).isNotNull();
+		assertThat(response.status()).isEqualTo(PostStatus.DELETED);
+	}
+
+	@Test
+	@DisplayName("게시글 상태 변경 - 실패 : 게시글 수정자 권한 없음")
+	void updatePostStatus_fail_invalidAccess() {
+		// given
+		User mockUser = makeMockUser();
+		long postId = 1L;
+		PostStatusUpdateReqDto request = new PostStatusUpdateReqDto(99L, PostStatus.NORMAL);
+		Post mockPost = makeMockPost(postId, mockUser);
+		mockPost.delete();
+		when(postRepository.findById(eq(postId))).thenReturn(Optional.of(mockPost));
+
+		// when && then
+		assertThatThrownBy(() -> postService.updatePostStatus(postId, request))
+				.isInstanceOf(InvalidAccessException.class)
+				.hasMessage("User {" + request.userId() + "} has no permission to update post status " + postId);
+	}
+
+	@Test
+	@DisplayName("게시글 조회 - 성공")
+	void findPost_success() {
+		// given
+		User mockUser = makeMockUser();
+		long postId = 1L;
+		Post mockPost = makeMockPost(postId, mockUser);
+		when(postRepository.findById(eq(postId))).thenReturn(Optional.of(mockPost));
+
+		// when
+		PostDetailResDto response = postService.findPostById(postId);
+
+		// then
+		verify(postRepository, times(1)).findById(postId);
+		assertThat(response.postId()).isEqualTo(postId);
+		assertThat(response.subject()).isNotNull();
+		assertThat(response.content()).isNotNull();
+		assertThat(response.createdAt()).isNotNull();
+		assertThat(response.modifiedAt()).isNotNull();
+		assertThat(response.status()).isNotNull();
+	}
+
+	@Test
+	@DisplayName("게시글 조회 - 실패 : 존재하지 않는 게시글")
+	void findPost_fail_postNotFound() {
+		// given
+		long postId = 1L;
+		when(postRepository.findById(eq(postId))).thenReturn(Optional.empty());
+
+		// when && then
+		assertThatThrownBy(() -> postService.findPostById(postId))
+				.isInstanceOf(PostNotFoundException.class)
+				.hasMessage("Post {" + postId + "} Not Found");
+	}
+
+}


### PR DESCRIPTION
게시글(Post) 도메인의 기본적인 CRUD 기능을 구현했습니다.

- 엔티티 연관관계 설정:
    - 게시글 기능을 위해 `User`와 `Post` 엔티티 간의 1:N 양방향 연관관계를 설정했습니다.
    - `User` 엔티티에 `addPost()` 편의 메소드를 추가했습니다.

- 게시글 CRUD API 구현:
    - `Post` 도메인의 Controller, Service, Repository, DTO 등 기본 골격을 구현했습니다.
    - 게시글 생성, 단일 조회, 수정, 삭제 API 엔드포인트를 추가했습니다.

- 예외 처리 추가: 여러 도메인에서 공통으로 사용할 `InvalidAccessException` 예외 클래스를 추가했습니다.
- 테스트 코드 작성: 구현된 비즈니스 로직에 대한 단위 테스트 및 통합 테스트 코드를 작성했습니다.