### PR TITLE
test(post): Post 관련 테스트에 Spring Security 인증 적용

### DIFF
--- a/back/src/main/java/dev/kyudong/back/common/config/SecurityConfig.java
+++ b/back/src/main/java/dev/kyudong/back/common/config/SecurityConfig.java
@@ -34,8 +34,7 @@ public class SecurityConfig {
 				.formLogin(AbstractHttpConfigurer::disable)
 				.sessionManagement(seession -> seession.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
 				.authorizeHttpRequests(auth ->
-					auth.requestMatchers(HttpMethod.GET, "/api/v1/post").permitAll()
-						.requestMatchers(HttpMethod.GET, "/api/v1/posts/{postId}/comments").permitAll()
+					auth.requestMatchers(HttpMethod.GET, "/api/v1/posts/**").permitAll()
 						.requestMatchers(HttpMethod.GET, "/swagger-ui/**", "/v3/api-docs/**").permitAll()
 						.requestMatchers(HttpMethod.POST, "/api/v1/users", "/api/v1/users/login").permitAll()
 						.anyRequest().authenticated()

--- a/back/src/main/java/dev/kyudong/back/post/api/PostApi.java
+++ b/back/src/main/java/dev/kyudong/back/post/api/PostApi.java
@@ -7,6 +7,7 @@ import dev.kyudong.back.post.api.dto.res.PostCreateResDto;
 import dev.kyudong.back.post.api.dto.res.PostDetailResDto;
 import dev.kyudong.back.post.api.dto.res.PostStatusUpdateResDto;
 import dev.kyudong.back.post.api.dto.res.PostUpdateResDto;
+import dev.kyudong.back.user.security.CustomUserPrincipal;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.headers.Header;
@@ -16,9 +17,12 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Positive;
 import org.springframework.http.MediaType;
 import org.springframework.http.ProblemDetail;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 
@@ -73,7 +77,7 @@ public interface PostApi {
 	})
 	ResponseEntity<PostDetailResDto> findPostById(
 			@Parameter(name = "postId", description = "조회할 게시글의 ID", required = true, example = "1")
-			@PathVariable long postId
+			@PathVariable @Positive Long postId
 	);
 
 	@SuppressWarnings("unused")
@@ -119,7 +123,10 @@ public interface PostApi {
 					)
 			),
 	})
-	ResponseEntity<PostCreateResDto> createUser(@RequestBody PostCreateReqDto request);
+	ResponseEntity<PostCreateResDto> createUser(
+			@RequestBody @Valid PostCreateReqDto request,
+			@Parameter(hidden = true) @AuthenticationPrincipal CustomUserPrincipal userPrincipal
+	);
 
 	@SuppressWarnings("unused")
 	@Operation(summary = "게시글 수정", description = "게시글을 수정합니다.")
@@ -175,8 +182,9 @@ public interface PostApi {
 	})
 	ResponseEntity<PostUpdateResDto> updatePost(
 			@Parameter(name = "postId", description = "수정할 게시글의 ID", required = true, example = "1")
-			@PathVariable long postId,
-			@RequestBody PostUpdateReqDto request
+			@PathVariable @Positive Long postId,
+			@RequestBody @Valid PostUpdateReqDto request,
+			@Parameter(hidden = true) @AuthenticationPrincipal CustomUserPrincipal userPrincipal
 	);
 
 	@SuppressWarnings("unused")
@@ -232,8 +240,9 @@ public interface PostApi {
 	})
 	ResponseEntity<PostStatusUpdateResDto> updatePostStatus(
 			@Parameter(name = "postId", description = "상태를 수정할 게시글의 ID", required = true, example = "1")
-			@PathVariable long postId,
-			@RequestBody PostStatusUpdateReqDto request
+			@PathVariable @Positive Long postId,
+			@RequestBody @Valid PostStatusUpdateReqDto request,
+			@Parameter(hidden = true) @AuthenticationPrincipal CustomUserPrincipal userPrincipal
 	);
 
 }

--- a/back/src/main/java/dev/kyudong/back/post/api/PostController.java
+++ b/back/src/main/java/dev/kyudong/back/post/api/PostController.java
@@ -8,8 +8,12 @@ import dev.kyudong.back.post.api.dto.res.PostDetailResDto;
 import dev.kyudong.back.post.api.dto.res.PostStatusUpdateResDto;
 import dev.kyudong.back.post.api.dto.res.PostUpdateResDto;
 import dev.kyudong.back.post.service.PostService;
+import dev.kyudong.back.user.security.CustomUserPrincipal;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Positive;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
@@ -17,21 +21,23 @@ import java.net.URI;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/v1/post")
+@RequestMapping("/api/v1/posts")
 public class PostController implements PostApi {
 
 	private final PostService postService;
 
 	@Override
 	@GetMapping("/{postId}")
-	public ResponseEntity<PostDetailResDto> findPostById(@PathVariable long postId) {
+	public ResponseEntity<PostDetailResDto> findPostById(@PathVariable @Positive Long postId) {
 		return ResponseEntity.ok(postService.findPostById(postId));
 	}
 
 	@Override
 	@PostMapping
-	public ResponseEntity<PostCreateResDto> createUser(PostCreateReqDto request) {
-		PostCreateResDto postCreateResDto = postService.createPost(request);
+	public ResponseEntity<PostCreateResDto> createUser(
+			@RequestBody @Valid PostCreateReqDto request,
+			@AuthenticationPrincipal CustomUserPrincipal userPrincipal) {
+		PostCreateResDto postCreateResDto = postService.createPost(userPrincipal.getId(), request);
 		URI uri = ServletUriComponentsBuilder.fromCurrentRequest()
 				.path("/{id}")
 				.buildAndExpand(postCreateResDto.postId())
@@ -41,14 +47,20 @@ public class PostController implements PostApi {
 
 	@Override
 	@PatchMapping("/{postId}/update")
-	public ResponseEntity<PostUpdateResDto> updatePost(@PathVariable long postId, PostUpdateReqDto request) {
-		return ResponseEntity.ok(postService.updatePost(postId, request));
+	public ResponseEntity<PostUpdateResDto> updatePost(
+			@PathVariable @Positive Long postId,
+			@RequestBody @Valid PostUpdateReqDto request,
+			@AuthenticationPrincipal CustomUserPrincipal userPrincipal) {
+		return ResponseEntity.ok(postService.updatePost(postId, userPrincipal.getId(), request));
 	}
 
 	@Override
 	@PatchMapping("/{postId}/status")
-	public ResponseEntity<PostStatusUpdateResDto> updatePostStatus(@PathVariable long postId, PostStatusUpdateReqDto request) {
-		return ResponseEntity.ok(postService.updatePostStatus(postId, request));
+	public ResponseEntity<PostStatusUpdateResDto> updatePostStatus(
+			@PathVariable @Positive Long postId,
+			@RequestBody @Valid PostStatusUpdateReqDto request,
+			@AuthenticationPrincipal CustomUserPrincipal userPrincipal) {
+		return ResponseEntity.ok(postService.updatePostStatus(postId, userPrincipal.getId(), request));
 	}
 
 }

--- a/back/src/main/java/dev/kyudong/back/post/api/dto/req/PostCreateReqDto.java
+++ b/back/src/main/java/dev/kyudong/back/post/api/dto/req/PostCreateReqDto.java
@@ -1,8 +1,14 @@
 package dev.kyudong.back.post.api.dto.req;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
 public record PostCreateReqDto(
-		long userId,
+		@Size(max = 100, message = "Subject cannot be longer than 100 characters.")
+		@NotBlank(message = "Subject can not be blank.")
 		String subject,
+
+		@NotBlank(message = "Content can not be blank.")
 		String content
 ) {
 }

--- a/back/src/main/java/dev/kyudong/back/post/api/dto/req/PostStatusUpdateReqDto.java
+++ b/back/src/main/java/dev/kyudong/back/post/api/dto/req/PostStatusUpdateReqDto.java
@@ -1,9 +1,10 @@
 package dev.kyudong.back.post.api.dto.req;
 
 import dev.kyudong.back.post.domain.PostStatus;
+import jakarta.validation.constraints.NotNull;
 
 public record PostStatusUpdateReqDto(
-		long userId,
+		@NotNull(message = "PostStatus can not be null.")
 		PostStatus status
 ) {
 }

--- a/back/src/main/java/dev/kyudong/back/post/api/dto/req/PostUpdateReqDto.java
+++ b/back/src/main/java/dev/kyudong/back/post/api/dto/req/PostUpdateReqDto.java
@@ -1,8 +1,14 @@
 package dev.kyudong.back.post.api.dto.req;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
 public record PostUpdateReqDto(
-		long userId,
+		@Size(max = 100, message = "Subject cannot be longer than 100 characters.")
+		@NotBlank(message = "Subject can not be blank.")
 		String subject,
+
+		@NotBlank(message = "Content can not be blank.")
 		String content
 ) {
 }

--- a/back/src/main/java/dev/kyudong/back/post/exception/PostNotFoundException.java
+++ b/back/src/main/java/dev/kyudong/back/post/exception/PostNotFoundException.java
@@ -1,7 +1,7 @@
 package dev.kyudong.back.post.exception;
 
 public class PostNotFoundException extends RuntimeException {
-	public PostNotFoundException(String message) {
-		super(message);
+	public PostNotFoundException(Long postId) {
+		super("Post {" + postId + "} Not Found");
 	}
 }

--- a/back/src/main/java/dev/kyudong/back/post/service/CommentService.java
+++ b/back/src/main/java/dev/kyudong/back/post/service/CommentService.java
@@ -51,7 +51,7 @@ public class CommentService {
 
 		if (!postRepository.existsById(postId)) {
 			log.warn("댓글 생성 실패 - 존재하지 않는 게시글 : postId: {}", postId);
-			throw new PostNotFoundException("Post {" + postId + "} Not Found");
+			throw new PostNotFoundException(postId);
 		}
 		Post post = postRepository.getReferenceById(postId);
 
@@ -78,7 +78,7 @@ public class CommentService {
 
 		if (!postRepository.existsById(postId)) {
 			log.warn("댓글 수정 실패 - 존재하지 않는 게시글 : postId: {}", postId);
-			throw new PostNotFoundException("Post {" + postId + "} Not Found");
+			throw new PostNotFoundException(postId);
 		}
 
 		Comment comment = commentRepository.findById(commentId)
@@ -106,7 +106,7 @@ public class CommentService {
 
 		if (!postRepository.existsById(postId)) {
 			log.warn("댓글 상태 수정 실패 - 존재하지 않는 게시글 : postId: {}", postId);
-			throw new PostNotFoundException("Post {" + postId + "} Not Found");
+			throw new PostNotFoundException(postId);
 		}
 
 		Comment comment = commentRepository.findById(commentId)

--- a/back/src/test/java/dev/kyudong/back/post/CommentControllerTests.java
+++ b/back/src/test/java/dev/kyudong/back/post/CommentControllerTests.java
@@ -131,7 +131,7 @@ public class CommentControllerTests {
 		Long postId = mockPost.getId();
 		CommentCreateReqDto request = new CommentCreateReqDto(mockUser.getId(), "Hello Comment");
 		when(commentService.createComment(eq(postId), any(CommentCreateReqDto.class)))
-				.thenThrow(new PostNotFoundException("Post {" + postId + "} Not Found"));
+				.thenThrow(new PostNotFoundException(postId));
 
 		// when & then
 		mockMvc.perform(post("/api/v1/posts/{postId}/comments", postId)

--- a/back/src/test/java/dev/kyudong/back/post/PostControllerTests.java
+++ b/back/src/test/java/dev/kyudong/back/post/PostControllerTests.java
@@ -1,7 +1,9 @@
 package dev.kyudong.back.post;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import dev.kyudong.back.common.config.SecurityConfig;
 import dev.kyudong.back.common.exception.InvalidAccessException;
+import dev.kyudong.back.common.jwt.JwtUtil;
 import dev.kyudong.back.post.api.PostController;
 import dev.kyudong.back.post.api.dto.req.PostCreateReqDto;
 import dev.kyudong.back.post.api.dto.req.PostStatusUpdateReqDto;
@@ -13,12 +15,15 @@ import dev.kyudong.back.post.api.dto.res.PostUpdateResDto;
 import dev.kyudong.back.post.domain.PostStatus;
 import dev.kyudong.back.post.exception.PostNotFoundException;
 import dev.kyudong.back.post.service.PostService;
+import dev.kyudong.back.security.WithMockCustomUser;
 import dev.kyudong.back.user.exception.UserNotFoundException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.MediaType;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -33,6 +38,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(PostController.class)
+@Import(SecurityConfig.class)
 public class PostControllerTests {
 
 	@Autowired
@@ -45,16 +51,24 @@ public class PostControllerTests {
 	@MockitoBean
 	private PostService postService;
 
+	@SuppressWarnings("unused")
+	@MockitoBean
+	private JwtUtil jwtUtil;
+
+	@SuppressWarnings("unused")
+	@MockitoBean
+	private UserDetailsService userDetailsService;
+
 	@Test
 	@DisplayName("게시글 조회 API - 성공")
 	void findPostByIdApi_success() throws Exception {
 		// given
-		long postId = 1L;
+		final Long postId = 1L;
 		PostDetailResDto response = new PostDetailResDto(postId, 1L, "Test", "Hello World!", PostStatus.NORMAL, LocalDateTime.now(), LocalDateTime.now());
 		when(postService.findPostById(eq(postId))).thenReturn(response);
 
 		// when & then
-		mockMvc.perform(get("/api/v1/post/{postId}", postId))
+		mockMvc.perform(get("/api/v1/posts/{postId}", postId))
 				.andExpect(status().isOk())
 				.andExpect(jsonPath("$.postId").value(postId))
 				.andExpect(jsonPath("$.subject").value("Test"))
@@ -63,15 +77,15 @@ public class PostControllerTests {
 	}
 
 	@Test
-	@DisplayName("게시글 조회 API - 실패 : 요청한 게시글이 존재하지 않음.")
+	@DisplayName("게시글 조회 API - 실패")
 	void findPostByIdApi_fail() throws Exception {
 		// given
-		long postId = 999L;
+		final Long postId = 999L;
 		when(postService.findPostById(eq(postId)))
-				.thenThrow(new PostNotFoundException("Post {" + postId + "} Not Found"));
+				.thenThrow(new PostNotFoundException(postId));
 
 		// when & then
-		mockMvc.perform(get("/api/v1/post/{postId}", postId))
+		mockMvc.perform(get("/api/v1/posts/{postId}", postId))
 				.andExpect(status().isNotFound())
 				.andExpect(jsonPath("$.title").value("Post Not Found"))
 				.andExpect(jsonPath("$.status").value(404))
@@ -81,15 +95,16 @@ public class PostControllerTests {
 
 	@Test
 	@DisplayName("게시글 생성 API - 성공")
+	@WithMockCustomUser
 	void createPostApi_success() throws Exception {
 		// given
-		long postId = 1L;
-		PostCreateReqDto request = new PostCreateReqDto(1L, "Test", "Hello World!");
+		final Long postId = 1L;
+		PostCreateReqDto request = new PostCreateReqDto("Test", "Hello World!");
 		PostCreateResDto response = new PostCreateResDto(postId, "Test", "Hello World!", LocalDateTime.now(), LocalDateTime.now());
-		when(postService.createPost(any(PostCreateReqDto.class))).thenReturn(response);
+		when(postService.createPost(eq(postId), any(PostCreateReqDto.class))).thenReturn(response);
 
 		// when & then
-		mockMvc.perform(post("/api/v1/post")
+		mockMvc.perform(post("/api/v1/posts")
 						.contentType(MediaType.APPLICATION_JSON.toString())
 						.content(objectMapper.writeValueAsString(request)))
 				.andExpect(status().isCreated())
@@ -100,35 +115,38 @@ public class PostControllerTests {
 	}
 
 	@Test
-	@DisplayName("게시글 생성 API - 실패 : 작성자의 정보가 조회가 안됨")
+	@DisplayName("게시글 생성 API - 실패 : 토큰은 유효하지만 DB에 작성자가 없는 경우")
+	@WithMockCustomUser(id = 999L)
 	void createPostApi_fail() throws Exception {
 		// given
-		PostCreateReqDto request = new PostCreateReqDto(1L, "Test", "Hello World!");
-		when(postService.createPost(any(PostCreateReqDto.class)))
-				.thenThrow(new UserNotFoundException("User {" + request.userId() + "} Not Found"));
+		final Long userId = 999L;
+		PostCreateReqDto request = new PostCreateReqDto("Test", "Hello World!");
+		when(postService.createPost(eq(userId), any(PostCreateReqDto.class)))
+				.thenThrow(new UserNotFoundException(userId));
 
 		// when & then
-		mockMvc.perform(post("/api/v1/post")
+		mockMvc.perform(post("/api/v1/posts")
 						.contentType(MediaType.APPLICATION_JSON.toString())
 						.content(objectMapper.writeValueAsString(request)))
 				.andExpect(status().isNotFound())
 				.andExpect(jsonPath("$.title").value("User Not Found"))
 				.andExpect(jsonPath("$.status").value(404))
-				.andExpect(jsonPath("$.detail").value("User {" + request.userId() + "} Not Found"))
+				.andExpect(jsonPath("$.detail").value("User {" + userId + "} Not Found"))
 				.andDo(print());
 	}
 
 	@Test
 	@DisplayName("게시글 수정 API - 성공")
+	@WithMockCustomUser
 	void updatePostApi_success() throws Exception {
 		// given
-		long postId = 1L;
-		PostUpdateReqDto request = new PostUpdateReqDto(1L, "Test", "Hello World!");
+		final Long postId = 1L;
+		PostUpdateReqDto request = new PostUpdateReqDto("Test", "Hello World!");
 		PostUpdateResDto response = new PostUpdateResDto(postId, "Test", "Hello World!", LocalDateTime.now(), LocalDateTime.now());
-		when(postService.updatePost(eq(postId), any(PostUpdateReqDto.class))).thenReturn(response);
+		when(postService.updatePost(eq(postId), eq(1L), any(PostUpdateReqDto.class))).thenReturn(response);
 
 		// when & then
-		mockMvc.perform(patch("/api/v1/post/{postId}/update", postId)
+		mockMvc.perform(patch("/api/v1/posts/{postId}/update", postId)
 						.contentType(MediaType.APPLICATION_JSON.toString())
 						.content(objectMapper.writeValueAsString(request)))
 				.andExpect(status().isOk())
@@ -140,35 +158,37 @@ public class PostControllerTests {
 
 	@Test
 	@DisplayName("게시글 수정 API - 실패 : 게시글 수정 권한 없음")
+	@WithMockCustomUser
 	void updatePostApi_fail() throws Exception {
 		// given
-		long postId = 1L;
-		PostUpdateReqDto request = new PostUpdateReqDto(1L, "Test", "Hello World!");
-		when(postService.updatePost(eq(postId), any(PostUpdateReqDto.class)))
-				.thenThrow(new InvalidAccessException("User {" + request.userId() + "} has no permission to update post " + postId));
+		final Long postId = 1L;
+		PostUpdateReqDto request = new PostUpdateReqDto( "Test", "Hello World!");
+		when(postService.updatePost(eq(postId), eq(1L), any(PostUpdateReqDto.class)))
+				.thenThrow(new InvalidAccessException("User {" + 1L + "} has no permission to update post " + postId));
 
 		// when & then
-		mockMvc.perform(patch("/api/v1/post/{postId}/update", postId)
+		mockMvc.perform(patch("/api/v1/posts/{postId}/update", postId)
 						.contentType(MediaType.APPLICATION_JSON.toString())
 						.content(objectMapper.writeValueAsString(request)))
 				.andExpect(status().isUnauthorized())
 				.andExpect(jsonPath("$.title").value("Access Denied"))
 				.andExpect(jsonPath("$.status").value(401))
-				.andExpect(jsonPath("$.detail").value("User {" + request.userId() + "} has no permission to update post " + postId))
+				.andExpect(jsonPath("$.detail").value("User {" + 1L + "} has no permission to update post " + postId))
 				.andDo(print());
 	}
 
 	@Test
 	@DisplayName("게시글 상태 수정 API")
+	@WithMockCustomUser
 	void updatePostStatusApi_success() throws Exception {
 		// given
-		long postId = 1L;
-		PostStatusUpdateReqDto request = new PostStatusUpdateReqDto(1L, PostStatus.DELETED);
+		final Long postId = 1L;
+		PostStatusUpdateReqDto request = new PostStatusUpdateReqDto(PostStatus.DELETED);
 		PostStatusUpdateResDto response = new PostStatusUpdateResDto(postId, PostStatus.DELETED);
-		when(postService.updatePostStatus(eq(postId), any(PostStatusUpdateReqDto.class))).thenReturn(response);
+		when(postService.updatePostStatus(eq(postId), eq(1L), any(PostStatusUpdateReqDto.class))).thenReturn(response);
 
 		// when & then
-		mockMvc.perform(patch("/api/v1/post/{postId}/status", postId)
+		mockMvc.perform(patch("/api/v1/posts/{postId}/status", postId)
 						.contentType(MediaType.APPLICATION_JSON.toString())
 						.content(objectMapper.writeValueAsString(request)))
 				.andExpect(status().isOk())
@@ -179,21 +199,22 @@ public class PostControllerTests {
 
 	@Test
 	@DisplayName("게시글 상태 수정 API - 실패 : 게시글 수정 권한 없음")
+	@WithMockCustomUser
 	void updatePostStatusApi_fail() throws Exception {
 		// given
-		long postId = 1L;
-		PostStatusUpdateReqDto request = new PostStatusUpdateReqDto(1L, PostStatus.DELETED);
-		when(postService.updatePostStatus(eq(postId), any(PostStatusUpdateReqDto.class)))
-				.thenThrow(new InvalidAccessException("User {" + request.userId() + "} has no permission to update post status " + postId));
+		final Long postId = 1L;
+		PostStatusUpdateReqDto request = new PostStatusUpdateReqDto(PostStatus.DELETED);
+		when(postService.updatePostStatus(eq(postId), eq(1L), any(PostStatusUpdateReqDto.class)))
+				.thenThrow(new InvalidAccessException("User {" + 1L + "} has no permission to update post status " + postId));
 
 		// when & then
-		mockMvc.perform(patch("/api/v1/post/{postId}/status", postId)
+		mockMvc.perform(patch("/api/v1/posts/{postId}/status", postId)
 						.contentType(MediaType.APPLICATION_JSON.toString())
 						.content(objectMapper.writeValueAsString(request)))
 				.andExpect(status().isUnauthorized())
 				.andExpect(jsonPath("$.title").value("Access Denied"))
 				.andExpect(jsonPath("$.status").value(401))
-				.andExpect(jsonPath("$.detail").value("User {" + request.userId() + "} has no permission to update post status " + postId))
+				.andExpect(jsonPath("$.detail").value("User {" + 1L + "} has no permission to update post status " + postId))
 				.andDo(print());
 	}
 


### PR DESCRIPTION
기존 Post 도메인의 컨트롤러 및 통합 테스트 코드를 새로 도입된 Spring Security 환경에 맞게 수정합니다.

그 외에 Exception 메시지 공통화와 SecurityConfig 에 Post 요청 주소를 수정 및 API 명세서를 수정하였습니다.

이 작업은 #10 에서 진행된 Spring Security 도입의 후속 조치입니다.