### PR TITLE
feat/알림 도메인 기초 CRUD API 구현

### DIFF
--- a/back/build.gradle
+++ b/back/build.gradle
@@ -29,6 +29,7 @@ dependencies {
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-websocket'
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
@@ -38,6 +39,7 @@ dependencies {
     annotationProcessor "org.springframework.boot:spring-boot-configuration-processor"
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
+    testImplementation 'org.springframework.boot:spring-boot-starter-websocket'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/back/src/main/java/dev/kyudong/back/common/config/WebSocketConfig.java
+++ b/back/src/main/java/dev/kyudong/back/common/config/WebSocketConfig.java
@@ -1,0 +1,23 @@
+package dev.kyudong.back.common.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.socket.WebSocketHandler;
+import org.springframework.web.socket.config.annotation.EnableWebSocket;
+import org.springframework.web.socket.config.annotation.WebSocketConfigurer;
+import org.springframework.web.socket.config.annotation.WebSocketHandlerRegistry;
+
+@Configuration
+@EnableWebSocket
+@RequiredArgsConstructor
+public class WebSocketConfig implements WebSocketConfigurer {
+
+	private final WebSocketHandler webSocketHandler;
+
+	@Override
+	public void registerWebSocketHandlers(WebSocketHandlerRegistry registry) {
+		registry.addHandler(webSocketHandler, "/ws/notifications")
+				.setAllowedOrigins("*"); // todo : 현재는 개발단계로 모든 도메인을 허용함, 추후 설정 필요
+	}
+
+}

--- a/back/src/main/java/dev/kyudong/back/common/exception/GlobalExceptionHandler.java
+++ b/back/src/main/java/dev/kyudong/back/common/exception/GlobalExceptionHandler.java
@@ -6,6 +6,7 @@ import dev.kyudong.back.follow.exception.AlreadyFollowException;
 import dev.kyudong.back.follow.exception.FollowingException;
 import dev.kyudong.back.interaction.exception.InteractionNotFoundException;
 import dev.kyudong.back.interaction.exception.InteractionTargetNotFoundException;
+import dev.kyudong.back.notification.exception.NotificationNotFoundException;
 import dev.kyudong.back.post.exception.CommentNotFoundException;
 import dev.kyudong.back.post.exception.PostNotFoundException;
 import dev.kyudong.back.user.exception.UserAlreadyExistsException;
@@ -135,6 +136,16 @@ public class GlobalExceptionHandler {
 	protected ResponseEntity<ProblemDetail> handleTargetNotFoundException(InteractionNotFoundException e) {
 		ProblemDetail problemDetail = ProblemDetail.forStatusAndDetail(HttpStatus.NOT_FOUND, e.getMessage());
 		problemDetail.setTitle("Interaction Not Found");
+		problemDetail.setStatus(HttpStatus.BAD_REQUEST);
+		problemDetail.setDetail(e.getMessage());
+		problemDetail.setProperty("timestamp", Instant.now());
+		return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(problemDetail);
+	}
+
+	@ExceptionHandler(NotificationNotFoundException.class)
+	protected ResponseEntity<ProblemDetail> handleNotificationNotFoundException(NotificationNotFoundException e) {
+		ProblemDetail problemDetail = ProblemDetail.forStatusAndDetail(HttpStatus.NOT_FOUND, e.getMessage());
+		problemDetail.setTitle("Notification Not Found");
 		problemDetail.setStatus(HttpStatus.BAD_REQUEST);
 		problemDetail.setDetail(e.getMessage());
 		problemDetail.setProperty("timestamp", Instant.now());

--- a/back/src/main/java/dev/kyudong/back/notification/api/NotificationApi.java
+++ b/back/src/main/java/dev/kyudong/back/notification/api/NotificationApi.java
@@ -1,0 +1,113 @@
+package dev.kyudong.back.notification.api;
+
+import dev.kyudong.back.notification.api.dto.res.NotificationResDto;
+import dev.kyudong.back.user.security.CustomUserPrincipal;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.constraints.Positive;
+import org.springframework.http.MediaType;
+import org.springframework.http.ProblemDetail;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
+
+/**
+ * Notification API의 명세를 정의하는 인터페이스입니다.
+ * <p>
+ * 이 인터페이스의 메소드들은 실제 코드에서 직접 호출되지 않지만,
+ * Spring MVC 프레임워크에 의해 런타임 시 동적으로 구현체(Controller)와 연결되어 사용됩니다.
+ * <p>
+ * 따라서 IDE에서 '사용되지 않음(unused)'으로 잘못 분석할 수 있으므로,
+ * {@code @SuppressWarnings("unused")}를 사용하여 관련 경고를 억제합니다.
+ *
+ * @see org.springframework.web.bind.annotation.RestController
+ * @see java.lang.SuppressWarnings
+ */
+@Tag(name = "Notification API", description = "알림 관련 API 명세서")
+public interface NotificationApi {
+
+	@SuppressWarnings("unused")
+	@Operation(summary = "사용자의 알림 목록을 조회", description = "사용자의 알림 목록을 조회합니다.")
+	@ApiResponses({
+			@ApiResponse(responseCode = "200", description = "알림 목록 조회",
+					content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+							schema = @Schema(implementation = NotificationResDto.class),
+							examples = @ExampleObject(value =
+									"""
+									{
+									  "lastFeedId": null,
+									  "hasNext": false,
+									  "content": [
+										{
+										  "id": 1,
+										  "receiverId": 1,
+										  "senderId": 2,
+										  "redirectUrl": "/post/1",
+										  "status": "POST",
+										  "createdAt": "2025-08-22T15:34:36.089587",
+										}
+									  ]
+									}
+									"""
+							)
+					)
+			),
+	})
+	ResponseEntity<NotificationResDto> findCommentsByPostId(
+			@Parameter(hidden = true, description = "로그인 사용자의 정보")
+			@AuthenticationPrincipal CustomUserPrincipal userPrincipal,
+			@Parameter(name = "lastFeedId", description = "마지막으로 조회한 알림의 아이디 (두 번째 페이지부터 사용됩니다)", example = "1")
+			@RequestParam(required = false) Long lastFeedId,
+			@Parameter(name = "size", description = "한 페이지에 불러올 알림 개수", example = "10")
+			@RequestParam(defaultValue = "10") @Positive int size
+	);
+
+	@SuppressWarnings("unused")
+	@Operation(summary = "사용자의 알림을 조회", description = "사용자의 알림을 아이디를 이용해 조회합니다")
+	@ApiResponses({
+			@ApiResponse(responseCode = "204", description = "사용자의 알림을 아이디를 이용해 조회합니다"),
+			@ApiResponse(responseCode = "404", description = "조회한 알림이 존재하지 않습니다",
+					content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+							schema = @Schema(implementation = ProblemDetail.class),
+							examples = @ExampleObject(value =
+									"""
+									{
+										"type": "about:blank",
+										"title": "Notification Not Found",
+										"status": 404,
+										"detail": "조회를 요청한 알림이 존재하지 않습니다: notificationId=1",
+										"instance": "/api/v1/notification/1",
+										"timestamp": "2025-08-16T16:20:22.367368100Z"
+									}
+									"""
+							)
+					)
+			),
+	})
+	ResponseEntity<Void> readNotification(
+			@Parameter(hidden = true, description = "로그인 사용자의 정보")
+			@AuthenticationPrincipal CustomUserPrincipal userPrincipal,
+			@Parameter(name = "notificationId", description = "조회할 알림 고유 아이디")
+			@PathVariable @Positive Long notificationId
+	);
+
+	@SuppressWarnings("unused")
+	@Operation(summary = "사용자의 알림을 삭제", description = "사용자의 알림을 아이디를 이용해 삭제합니다")
+	@ApiResponses({
+			@ApiResponse(responseCode = "204", description = "사용자의 알림을 아이디를 이용해 삭제합니다")
+	})
+	ResponseEntity<Void> deleteNotification(
+			@Parameter(hidden = true, description = "로그인 사용자의 정보")
+			@AuthenticationPrincipal CustomUserPrincipal userPrincipal,
+			@Parameter(name = "notificationId", description = "조회할 알림 고유 아이디")
+			@PathVariable @Positive Long notificationId
+	);
+
+}

--- a/back/src/main/java/dev/kyudong/back/notification/api/NotificationController.java
+++ b/back/src/main/java/dev/kyudong/back/notification/api/NotificationController.java
@@ -1,0 +1,46 @@
+package dev.kyudong.back.notification.api;
+
+import dev.kyudong.back.notification.api.dto.res.NotificationResDto;
+import dev.kyudong.back.notification.service.NotificationService;
+import dev.kyudong.back.user.security.CustomUserPrincipal;
+import jakarta.validation.constraints.Positive;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/notification")
+public class NotificationController implements NotificationApi {
+
+	private final NotificationService notificationService;
+
+	@Override
+	@GetMapping
+	public ResponseEntity<NotificationResDto> findCommentsByPostId(
+			@AuthenticationPrincipal CustomUserPrincipal userPrincipal,
+			@RequestParam(required = false) Long lastNotificationId,
+			@RequestParam(defaultValue = "10") @Positive int size) {
+		return ResponseEntity.ok(notificationService.findNotifications(userPrincipal.getId(), lastNotificationId, size));
+	}
+
+	@Override
+	@PatchMapping("/{notificationId}")
+	public ResponseEntity<Void> readNotification(
+			@AuthenticationPrincipal CustomUserPrincipal userPrincipal,
+			@PathVariable @Positive Long notificationId) {
+		notificationService.readNotification(userPrincipal.getId(), notificationId);
+		return ResponseEntity.noContent().build();
+	}
+
+	@Override
+	@DeleteMapping("/{notificationId}")
+	public ResponseEntity<Void> deleteNotification(
+			@AuthenticationPrincipal CustomUserPrincipal userPrincipal,
+			@PathVariable @Positive Long notificationId) {
+		notificationService.deleteNotification(userPrincipal.getId(), notificationId);
+		return ResponseEntity.noContent().build();
+	}
+
+}

--- a/back/src/main/java/dev/kyudong/back/notification/api/dto/res/NotificationDetailResDto.java
+++ b/back/src/main/java/dev/kyudong/back/notification/api/dto/res/NotificationDetailResDto.java
@@ -1,0 +1,27 @@
+package dev.kyudong.back.notification.api.dto.res;
+
+import dev.kyudong.back.notification.domain.Notification;
+import dev.kyudong.back.notification.domain.NotificationType;
+
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+
+public record NotificationDetailResDto(
+		Long id,
+		Long receiverId,
+		Long senderId,
+		String redirectUrl,
+		NotificationType notificationType,
+		LocalDateTime createdAt
+) {
+	public static NotificationDetailResDto from(Notification notification) {
+		return new NotificationDetailResDto(
+			notification.getId(),
+			notification.getReceiver().getId(),
+			notification.getSender().getId(),
+			notification.getRedirectUrl(),
+			notification.getType(),
+			LocalDateTime.ofInstant(notification.getCreatedAt(), ZoneOffset.UTC)
+		);
+	}
+}

--- a/back/src/main/java/dev/kyudong/back/notification/api/dto/res/NotificationResDto.java
+++ b/back/src/main/java/dev/kyudong/back/notification/api/dto/res/NotificationResDto.java
@@ -1,0 +1,27 @@
+package dev.kyudong.back.notification.api.dto.res;
+
+import dev.kyudong.back.notification.domain.Notification;
+import org.springframework.data.domain.Slice;
+
+import java.util.List;
+
+public record NotificationResDto(
+		Long lastNotificationId,
+		boolean hasNext,
+		List<NotificationDetailResDto> content
+) {
+	public static NotificationResDto from(Slice<Notification> notifications) {
+		List<NotificationDetailResDto> content = notifications.getContent().stream()
+				.map(NotificationDetailResDto::from)
+				.toList();
+
+		Long lastNotificationId = null;
+		boolean hasNext = notifications.hasNext();
+
+		if (hasNext) {
+			lastNotificationId = content.get(content.size() - 1 ).id();
+		}
+
+		return new NotificationResDto(lastNotificationId, hasNext, content);
+	}
+}

--- a/back/src/main/java/dev/kyudong/back/notification/domain/Notification.java
+++ b/back/src/main/java/dev/kyudong/back/notification/domain/Notification.java
@@ -1,0 +1,64 @@
+package dev.kyudong.back.notification.domain;
+
+import dev.kyudong.back.user.domain.User;
+import jakarta.persistence.*;
+import lombok.*;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.Instant;
+
+@Entity
+@Getter
+@ToString(exclude = {"receiver", "sender"})
+@Table(name = "NOTIFICATIONS")
+@EntityListeners(AuditingEntityListener.class)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Notification {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "ID", updatable = false)
+	private Long id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "RECEIVER_ID", nullable = false)
+	private User receiver;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "SENDER_ID", nullable = false)
+	private User sender;
+
+	@Column(name = "REDIRECT_URL")
+	private String redirectUrl;
+
+	@Enumerated(EnumType.STRING)
+	@Column(name = "TYPE", nullable = false)
+	private NotificationType type;
+
+	@Column(name = "IS_READ", nullable = false)
+	private boolean isRead;
+
+	@CreatedDate
+	@Column(name = "CREATED_AT", updatable = false)
+	private Instant createdAt;
+
+	@LastModifiedDate
+	@Column(name = "READ_AT", updatable = false)
+	private Instant readAt;
+
+	@Builder
+	private Notification(User receiver, User sender, String redirectUrl, NotificationType type) {
+		this.receiver = receiver;
+		this.sender = sender;
+		this.redirectUrl = redirectUrl;
+		this.type = type;
+		this.isRead = false;
+	}
+
+	public void read() {
+		this.isRead = true;
+	}
+
+}

--- a/back/src/main/java/dev/kyudong/back/notification/domain/NotificationType.java
+++ b/back/src/main/java/dev/kyudong/back/notification/domain/NotificationType.java
@@ -1,0 +1,8 @@
+package dev.kyudong.back.notification.domain;
+
+public enum NotificationType {
+
+	POST,
+	FOLLOW,
+
+}

--- a/back/src/main/java/dev/kyudong/back/notification/event/DefaultNotificationEventHandler.java
+++ b/back/src/main/java/dev/kyudong/back/notification/event/DefaultNotificationEventHandler.java
@@ -1,0 +1,72 @@
+package dev.kyudong.back.notification.event;
+
+import dev.kyudong.back.follow.domain.Follow;
+import dev.kyudong.back.follow.repository.FollowRepository;
+import dev.kyudong.back.notification.domain.Notification;
+import dev.kyudong.back.notification.domain.NotificationType;
+import dev.kyudong.back.notification.handler.NotificationWebSocketHandler;
+import dev.kyudong.back.notification.api.dto.res.NotificationDetailResDto;
+import dev.kyudong.back.notification.repository.NotificationRepository;
+import dev.kyudong.back.notification.utils.RedirectUrlCreator;
+import dev.kyudong.back.post.api.dto.event.PostCreateNotification;
+import dev.kyudong.back.user.domain.User;
+import dev.kyudong.back.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class DefaultNotificationEventHandler implements NotificationEventHandler {
+
+	private final NotificationRepository notificationRepository;
+	private final FollowRepository followRepository;
+	private final UserRepository userRepository;
+	private final NotificationWebSocketHandler notificationWebSocketHandler;
+	private final RedirectUrlCreator redirectUrlCreator;
+
+	@Override
+	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+	@Transactional(propagation = Propagation.REQUIRES_NEW)
+	public void handlePostCreateEvent(PostCreateNotification event) {
+		final Long postId = event.postId();
+		log.info("게시글 생성 이벤트 수신완료, 알림 이벤트를 시작합니다: postId={}", postId);
+
+		User sender = userRepository.getReferenceById(event.senderId());
+		List<User> followers = followRepository.findByFollowingWithFollower(sender).stream()
+				.map(Follow::getFollower)
+				.toList();
+
+		if (followers.isEmpty()) {
+			log.debug("팔로워가 없어 알림 생성을 중지합니다: senderId={}, postId={}", event.senderId(), postId);
+			return;
+		}
+
+		String redirectUrl = redirectUrlCreator.createPostUrl(event.postId());
+		List<Notification> newNotifications = followers.stream()
+				.map(receiver ->
+					Notification.builder()
+								.receiver(receiver)
+								.sender(sender)
+								.redirectUrl(redirectUrl)
+								.type(NotificationType.POST)
+								.build()
+				)
+				.toList();
+		List<Notification> savedNotifications = notificationRepository.saveAll(newNotifications);
+		log.info("팔로워 {}에게 알림을 생성했습니다: postId={}", savedNotifications.size(), postId);
+
+		savedNotifications.forEach(notification -> {
+			NotificationDetailResDto notificationDetailResDto = NotificationDetailResDto.from(notification);
+			notificationWebSocketHandler.sendMessageToUser(notificationDetailResDto.receiverId(), notificationDetailResDto);
+		});
+	}
+
+}

--- a/back/src/main/java/dev/kyudong/back/notification/event/NotificationEventHandler.java
+++ b/back/src/main/java/dev/kyudong/back/notification/event/NotificationEventHandler.java
@@ -1,0 +1,9 @@
+package dev.kyudong.back.notification.event;
+
+import dev.kyudong.back.post.api.dto.event.PostCreateNotification;
+
+public interface NotificationEventHandler {
+
+	void handlePostCreateEvent(PostCreateNotification event);
+
+}

--- a/back/src/main/java/dev/kyudong/back/notification/exception/NotificationNotFoundException.java
+++ b/back/src/main/java/dev/kyudong/back/notification/exception/NotificationNotFoundException.java
@@ -1,0 +1,7 @@
+package dev.kyudong.back.notification.exception;
+
+public class NotificationNotFoundException extends RuntimeException {
+	public NotificationNotFoundException(Long notificationId) {
+		super(String.format("조회를 요청한 알림이 존재하지 않습니다: notificationId=%d", notificationId));
+	}
+}

--- a/back/src/main/java/dev/kyudong/back/notification/handler/NotificationWebSocketHandler.java
+++ b/back/src/main/java/dev/kyudong/back/notification/handler/NotificationWebSocketHandler.java
@@ -1,0 +1,70 @@
+package dev.kyudong.back.notification.handler;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import dev.kyudong.back.notification.api.dto.res.NotificationDetailResDto;
+import dev.kyudong.back.user.security.CustomUserPrincipal;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.CloseStatus;
+import org.springframework.web.socket.TextMessage;
+import org.springframework.web.socket.WebSocketSession;
+import org.springframework.web.socket.handler.TextWebSocketHandler;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class NotificationWebSocketHandler extends TextWebSocketHandler {
+
+	private final Map<Long, WebSocketSession> sessions = new ConcurrentHashMap<>();
+	private final ObjectMapper objectMapper;
+
+	@Override
+	public void afterConnectionEstablished(WebSocketSession session) throws Exception {
+		Long userId = getUserId(session);
+		if (userId == null) {
+			log.warn("웹 소켓 연결에 실패했습니다: 사용자 인증 실패");
+			session.close(CloseStatus.POLICY_VIOLATION.withReason("사용자 인증 실패"));
+			return;
+		}
+		sessions.put(userId, session);
+	}
+
+	@Override
+	public void afterConnectionClosed(WebSocketSession session, CloseStatus status) throws Exception {
+		Long userId  = getUserId(session);
+		if (userId != null) {
+			sessions.remove(userId);
+			log.info("웹 소켓 연결이 종료되었습니다: userId={} status={}", userId, status);
+		}
+	}
+
+	public void sendMessageToUser(final Long userId, NotificationDetailResDto notificationDetailResDto) {
+		log.debug("메시지를 전송을 시작합니다: userId={}", userId);
+		WebSocketSession session = sessions.get(userId);
+		if (session != null && session.isOpen()) {
+			try {
+				String message = objectMapper.writeValueAsString(notificationDetailResDto);
+				session.sendMessage(new TextMessage(message));
+				log.info("메시지 전송를 전송했습니다: userId={}. message={}", userId, message);
+			} catch (IOException e) {
+				log.error("메시지 전달에 실패했습니다: userId={}", userId);
+			}
+		}
+	}
+
+	private Long getUserId(WebSocketSession session) {
+		if (session.getPrincipal() instanceof Authentication authentication) {
+			if (authentication.getPrincipal() instanceof CustomUserPrincipal) {
+				return ((CustomUserPrincipal) authentication.getPrincipal()).getId();
+			}
+		}
+		return null;
+	}
+
+}

--- a/back/src/main/java/dev/kyudong/back/notification/repository/NotificationRepository.java
+++ b/back/src/main/java/dev/kyudong/back/notification/repository/NotificationRepository.java
@@ -1,0 +1,49 @@
+package dev.kyudong.back.notification.repository;
+
+import dev.kyudong.back.notification.domain.Notification;
+import dev.kyudong.back.user.domain.User;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+
+public interface NotificationRepository extends JpaRepository<Notification, Long> {
+
+	List<Notification> findByCreatedAtBefore(Instant threshold);
+
+	@Query("""
+			SELECT n
+			FROM Notification n
+			JOIN FETCH n.receiver
+			WHERE n.receiver = :receiver
+			AND n.id < :lastNotificationId
+			ORDER BY n.id DESC, n.createdAt DESC
+	""")
+	Slice<Notification> findNotificationByReceiver(
+			@Param("receiver") User receiver,
+			@Param("lastNotificationId") Long lastNotificationId,
+			Pageable pageable
+	);
+
+	@Query("""
+			SELECT n
+			FROM Notification n
+			JOIN FETCH n.receiver
+			WHERE n.receiver = :receiver
+			ORDER BY n.id DESC, n.createdAt DESC
+	""")
+	Slice<Notification> findNotificationByReceiver(
+			@Param("receiver") User receiver,
+			Pageable pageable
+	);
+
+	Optional<Notification> findByIdAndReceiver(Long notificationId, User receiver);
+
+	void deleteByIdAndReceiver(Long notificationId, User receiver);
+
+}

--- a/back/src/main/java/dev/kyudong/back/notification/scheduler/NotificationScheduler.java
+++ b/back/src/main/java/dev/kyudong/back/notification/scheduler/NotificationScheduler.java
@@ -1,0 +1,44 @@
+package dev.kyudong.back.notification.scheduler;
+
+import dev.kyudong.back.notification.domain.Notification;
+import dev.kyudong.back.notification.repository.NotificationRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class NotificationScheduler {
+
+	private final NotificationRepository notificationRepository;
+
+	@Scheduled(cron = "0 30 3 * * *")
+	@Transactional
+	public void cleanupOrphanedNotification() {
+		log.info("오래된 알림을 정리를 시작합니다........");
+
+		// 현재 시점에서 1년 이전의 알림이 기준
+		Instant threshold = Instant.now().minus(366, ChronoUnit.DAYS);
+
+		List<Notification> orphanedNotification = notificationRepository.findByCreatedAtBefore(threshold);
+
+		if (orphanedNotification.isEmpty()) {
+			log.info("정리할 알림이 없습니다.........");
+			return;
+		}
+
+		int notificationSize = orphanedNotification.size();
+		log.info("{}개의 알림을 정리합니다!", notificationSize);
+
+		notificationRepository.deleteAll(orphanedNotification);
+		log.info("오래된 알림 {}개의 정리가 완료되었습니다", notificationSize);
+	}
+
+}

--- a/back/src/main/java/dev/kyudong/back/notification/service/NotificationService.java
+++ b/back/src/main/java/dev/kyudong/back/notification/service/NotificationService.java
@@ -1,0 +1,63 @@
+package dev.kyudong.back.notification.service;
+
+import dev.kyudong.back.notification.api.dto.res.NotificationResDto;
+import dev.kyudong.back.notification.domain.Notification;
+import dev.kyudong.back.notification.exception.NotificationNotFoundException;
+import dev.kyudong.back.notification.repository.NotificationRepository;
+import dev.kyudong.back.user.domain.User;
+import dev.kyudong.back.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class NotificationService {
+
+	private final UserRepository userRepository;
+	private final NotificationRepository notificationRepository;
+
+	@Transactional(readOnly = true)
+	public NotificationResDto findNotifications(final Long receiverId, Long lastNotificationId, int size) {
+		log.debug("알림 목록을 조회합니다: receiverId={}, lastNotificationId={}, size={}", receiverId, lastNotificationId, size);
+		User receiver = userRepository.getReferenceById(receiverId);
+		PageRequest pageRequest = PageRequest.of(0, size);
+
+		Slice<Notification> notifications = (lastNotificationId == null)
+				? notificationRepository.findNotificationByReceiver(receiver, pageRequest)
+				: notificationRepository.findNotificationByReceiver(receiver, lastNotificationId, pageRequest);
+
+		log.info("알림 목록을 조회했습니다: receiverId={}", receiverId);
+		return NotificationResDto.from(notifications);
+	}
+
+	@Transactional
+	public void readNotification(final Long receiverId, final Long notificationId) {
+		log.debug("알림을 조회합니다: receiverId={}, notificationId={}", receiverId, notificationId);
+
+		User receiver = userRepository.getReferenceById(receiverId);
+		Notification notification = notificationRepository.findByIdAndReceiver(notificationId, receiver)
+				.orElseThrow(() -> {
+					log.warn("조회할 알림이 존재하지 않습니다: receiverId={}, notificationId={}", receiverId, notificationId);
+					return new NotificationNotFoundException(notificationId);
+				});
+
+		notification.read();
+		log.info("알림 조회를 완료했습니다: receiverId={}, notificationId={}", receiverId, notificationId);
+	}
+
+	@Transactional
+	public void deleteNotification(final Long receiverId, final Long notificationId) {
+		log.debug("알림을 삭제합니다: notificationId={}", notificationId);
+
+		User receiver = userRepository.getReferenceById(receiverId);
+		notificationRepository.deleteByIdAndReceiver(notificationId, receiver);
+
+		log.info("알림 삭제를 완료했습니다: notificationId={}", notificationId);
+	}
+
+}

--- a/back/src/main/java/dev/kyudong/back/notification/utils/RedirectUrlCreator.java
+++ b/back/src/main/java/dev/kyudong/back/notification/utils/RedirectUrlCreator.java
@@ -1,0 +1,16 @@
+package dev.kyudong.back.notification.utils;
+
+import org.springframework.stereotype.Component;
+import org.springframework.web.util.UriComponentsBuilder;
+
+@Component
+public class RedirectUrlCreator {
+
+	public String createPostUrl(Long postId) {
+		return UriComponentsBuilder.newInstance()
+				.path("/post/{postId}")
+				.buildAndExpand(postId)
+				.toUriString();
+	}
+
+}

--- a/back/src/main/java/dev/kyudong/back/post/api/dto/event/PostCreateNotification.java
+++ b/back/src/main/java/dev/kyudong/back/post/api/dto/event/PostCreateNotification.java
@@ -1,0 +1,7 @@
+package dev.kyudong.back.post.api.dto.event;
+
+public record PostCreateNotification(
+		Long postId,
+		Long senderId
+) {
+}

--- a/back/src/main/java/dev/kyudong/back/post/service/PostService.java
+++ b/back/src/main/java/dev/kyudong/back/post/service/PostService.java
@@ -4,6 +4,7 @@ import dev.kyudong.back.common.exception.InvalidAccessException;
 import dev.kyudong.back.common.exception.InvalidInputException;
 import dev.kyudong.back.post.api.dto.event.PostCreateFeedEvent;
 import dev.kyudong.back.post.api.dto.event.PostCreateFileEvent;
+import dev.kyudong.back.post.api.dto.event.PostCreateNotification;
 import dev.kyudong.back.post.api.dto.event.PostUpdateFileEvent;
 import dev.kyudong.back.post.api.dto.req.PostCreateReqDto;
 import dev.kyudong.back.post.api.dto.req.PostStatusUpdateReqDto;
@@ -75,6 +76,10 @@ public class PostService {
 		// feed 추가
 		PostCreateFeedEvent feedEvent = new PostCreateFeedEvent(savedPost, user);
 		applicationEventPublisher.publishEvent(feedEvent);
+
+		// 알림 이벤트 추가
+		PostCreateNotification notificationEvent = new PostCreateNotification(postId, userId);
+		applicationEventPublisher.publishEvent(notificationEvent);
 
 		log.info("게시글 생성에 성공했습니다: userId={}, postId={}", userId, postId);
 		return PostCreateResDto.from(savedPost);

--- a/back/src/test/java/dev/kyudong/back/notification/NotificationControllerTests.java
+++ b/back/src/test/java/dev/kyudong/back/notification/NotificationControllerTests.java
@@ -1,0 +1,189 @@
+package dev.kyudong.back.notification;
+
+import dev.kyudong.back.common.config.SecurityConfig;
+import dev.kyudong.back.common.jwt.JwtUtil;
+import dev.kyudong.back.notification.api.NotificationController;
+import dev.kyudong.back.notification.api.dto.res.NotificationDetailResDto;
+import dev.kyudong.back.notification.api.dto.res.NotificationResDto;
+import dev.kyudong.back.notification.domain.Notification;
+import dev.kyudong.back.notification.domain.NotificationType;
+import dev.kyudong.back.notification.exception.NotificationNotFoundException;
+import dev.kyudong.back.notification.service.NotificationService;
+import dev.kyudong.back.security.WithMockCustomUser;
+import dev.kyudong.back.user.domain.User;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.Instant;
+import java.util.List;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.mockito.BDDMockito.*;
+
+@WebMvcTest(NotificationController.class)
+@Import(SecurityConfig.class)
+public class NotificationControllerTests {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@SuppressWarnings("unused")
+	@MockitoBean
+	private NotificationService notificationService;
+
+	@SuppressWarnings("unused")
+	@MockitoBean
+	private JwtUtil jwtUtil;
+
+	@SuppressWarnings("unused")
+	@MockitoBean
+	private UserDetailsService userDetailsService;
+
+	private static User makeMockUser(String username, Long id) {
+		User mockUser = User.builder()
+				.username(username)
+				.rawPassword("rawPassword")
+				.encodedPassword("encodedPassword")
+				.build();
+		ReflectionTestUtils.setField(mockUser, "id", id);
+		return mockUser;
+	}
+
+	private static Notification makeMockNotification(User receiver, User sender, Long id) {
+		Notification notification = Notification.builder()
+				.receiver(receiver)
+				.sender(sender)
+				.redirectUrl("/post/1")
+				.type(NotificationType.POST)
+				.build();
+		ReflectionTestUtils.setField(notification, "id", id);
+		ReflectionTestUtils.setField(notification, "createdAt", Instant.now());
+		return notification;
+	}
+
+	@Test
+	@DisplayName("알림 목록 조회 API - 성공: 첫 조회")
+	@WithMockCustomUser
+	void findNotificationsApi_success() throws Exception {
+		// given
+		User mockReceiver = makeMockUser("dxfxd", 1L);
+		User mockSender = makeMockUser("zxqzz", 2L);
+
+		NotificationDetailResDto notification1 =
+				NotificationDetailResDto.from(makeMockNotification(mockReceiver, mockSender, 1L));
+		NotificationDetailResDto notification2 =
+				NotificationDetailResDto.from(makeMockNotification(mockReceiver, mockSender, 2L));
+		NotificationDetailResDto notification3 =
+				NotificationDetailResDto.from(makeMockNotification(mockReceiver, mockSender, 3L));
+		List<NotificationDetailResDto> content = List.of(notification1, notification2, notification3);
+		NotificationResDto response = new NotificationResDto(2L, true, content);
+
+		given(notificationService.findNotifications(1L, null, 10))
+				.willReturn(response);
+
+		// when & then
+		mockMvc.perform(get("/api/v1/notification")
+						.param("size", "10"))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.lastNotificationId").hasJsonPath())
+				.andExpect(jsonPath("$.hasNext").value(true))
+				.andExpect(jsonPath("$.content").isArray())
+				.andDo(print());
+	}
+
+	@Test
+	@DisplayName("알림 목록 조회 API - 성공: 알림 아이디로 조회")
+	@WithMockCustomUser
+	void findNotificationsApi_success_withLastNotificationId() throws Exception {
+		// given
+		User mockReceiver = makeMockUser("dxfxd", 1L);
+		User mockSender = makeMockUser("zxqzz", 2L);
+
+		NotificationDetailResDto notification1 =
+				NotificationDetailResDto.from(makeMockNotification(mockReceiver, mockSender, 1L));
+		NotificationDetailResDto notification2 =
+				NotificationDetailResDto.from(makeMockNotification(mockReceiver, mockSender, 2L));
+		NotificationDetailResDto notification3 =
+				NotificationDetailResDto.from(makeMockNotification(mockReceiver, mockSender, 3L));
+		List<NotificationDetailResDto> content = List.of(notification1, notification2, notification3);
+		NotificationResDto response = new NotificationResDto(2L, true, content);
+
+		given(notificationService.findNotifications(1L, 2L, 10))
+				.willReturn(response);
+
+		// when & then
+		mockMvc.perform(get("/api/v1/notification")
+						.param("size", "10")
+						.param("lastNotificationId", "2"))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.lastNotificationId").value(2L))
+				.andExpect(jsonPath("$.hasNext").value(true))
+				.andExpect(jsonPath("$.content").isArray())
+				.andDo(print());
+	}
+
+	@Test
+	@DisplayName("알림 조회 API")
+	@WithMockCustomUser
+	void readNotificationApi_success() throws Exception {
+		// given
+		final Long receiverId = 1L;
+		final Long notificationId = 1L;
+
+		// when
+		mockMvc.perform(patch("/api/v1/notification/{notificationId}", notificationId))
+				.andExpect(status().isNoContent())
+				.andDo(print());
+
+		// then
+		then(notificationService).should().readNotification(receiverId, notificationId);
+	}
+
+	@Test
+	@DisplayName("알림 조회 API")
+	@WithMockCustomUser
+	void readNotificationApi_fail_notificationNotFound() throws Exception {
+		// given
+		final Long receiverId = 1L;
+		final Long notificationId = 1L;
+
+		willThrow(new NotificationNotFoundException(notificationId))
+				.given(notificationService).readNotification(receiverId, notificationId);
+
+		// when
+		mockMvc.perform(patch("/api/v1/notification/{notificationId}", notificationId))
+				.andExpect(status().isBadRequest())
+				.andDo(print());
+
+		// then
+		then(notificationService).should().readNotification(receiverId, notificationId);
+	}
+
+	@Test
+	@DisplayName("알림 삭제 API")
+	@WithMockCustomUser
+	void deleteNotification_success() throws Exception {
+		// given
+		final Long receiverId = 1L;
+		final Long notificationId = 1L;
+
+		// when
+		mockMvc.perform(delete("/api/v1/notification/{notificationId}", notificationId))
+				.andExpect(status().isNoContent())
+				.andDo(print());
+
+		// then
+		then(notificationService).should().deleteNotification(receiverId, notificationId);
+	}
+
+}

--- a/back/src/test/java/dev/kyudong/back/notification/NotificationEventHandlerTests.java
+++ b/back/src/test/java/dev/kyudong/back/notification/NotificationEventHandlerTests.java
@@ -1,0 +1,122 @@
+package dev.kyudong.back.notification;
+
+import dev.kyudong.back.follow.domain.Follow;
+import dev.kyudong.back.follow.repository.FollowRepository;
+import dev.kyudong.back.notification.api.dto.res.NotificationDetailResDto;
+import dev.kyudong.back.notification.domain.Notification;
+import dev.kyudong.back.notification.event.DefaultNotificationEventHandler;
+import dev.kyudong.back.notification.handler.NotificationWebSocketHandler;
+import dev.kyudong.back.notification.repository.NotificationRepository;
+import dev.kyudong.back.notification.utils.RedirectUrlCreator;
+import dev.kyudong.back.post.api.dto.event.PostCreateNotification;
+import dev.kyudong.back.post.domain.Post;
+import dev.kyudong.back.user.domain.User;
+import dev.kyudong.back.user.repository.UserRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.Instant;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.times;
+
+@ExtendWith(MockitoExtension.class)
+public class NotificationEventHandlerTests {
+
+	@Mock
+	private UserRepository userRepository;
+
+	@Mock
+	private FollowRepository followRepository;
+
+	@Mock
+	private NotificationRepository notificationRepository;
+
+	@InjectMocks
+	private DefaultNotificationEventHandler defaultNotificationEventHandler;
+
+	@Mock
+	private RedirectUrlCreator redirectUrlCreator;
+
+	@Mock
+	private NotificationWebSocketHandler notificationWebSocketHandler;
+
+	private static User makeMockUser(String username, Long id) {
+		User mockUser = User.builder()
+				.username(username)
+				.rawPassword("passWord")
+				.encodedPassword("passWord")
+				.build();
+		ReflectionTestUtils.setField(mockUser, "id", id);
+		return mockUser;
+	}
+
+	private static Post makeMockPost(User mockUser) {
+		Post mockPost = Post.builder()
+				.subject("subject")
+				.content("content")
+				.build();
+		ReflectionTestUtils.setField(mockPost, "id", 1L);
+		ReflectionTestUtils.setField(mockPost, "user", mockUser);
+		return mockPost;
+	}
+
+	private static Follow makeMockFollow(User follower, User following, Long id) {
+		Follow follow = Follow.builder()
+				.follower(follower)
+				.following(following)
+				.build();
+		ReflectionTestUtils.setField(follow, "id", id);
+		return follow;
+	}
+
+	@Test
+	@DisplayName("알림 생성 이벤트 - 성공")
+	void handlePostCreateEvent_success() {
+		// given
+		User mockFollowing = makeMockUser("cnzn1d", 999L);
+		given(userRepository.getReferenceById(mockFollowing.getId())).willReturn(mockFollowing);
+
+		Post mockPost = makeMockPost(mockFollowing);
+		User mockFollower1 = makeMockUser("ckzxv2", 1L);
+		User mockFollower2 = makeMockUser("ccxvn1sd", 2L);
+		User mockFollower3 = makeMockUser("ckj31zz", 3L);
+
+		List<Follow> mockFollows = List.of(
+				makeMockFollow(mockFollower1, mockFollowing, 1L),
+				makeMockFollow(mockFollower2, mockFollowing, 2L),
+				makeMockFollow(mockFollower3, mockFollowing, 3L)
+		);
+		PostCreateNotification event = new PostCreateNotification(mockPost.getId(), mockFollowing.getId());
+
+		given(followRepository.findByFollowingWithFollower(mockFollowing)).willReturn(mockFollows);
+		given(redirectUrlCreator.createPostUrl(mockPost.getId())).willReturn("/ex");
+		given(notificationRepository.saveAll(anyList())).willAnswer(invocation -> {
+			List<Notification> notifications = invocation.getArgument(0);
+			long tempId = 1L;
+			for (Notification n : notifications) {
+				ReflectionTestUtils.setField(n, "id", tempId++);
+				ReflectionTestUtils.setField(n, "createdAt", Instant.now());
+			}
+			return notifications;
+		});
+
+		// when
+		defaultNotificationEventHandler.handlePostCreateEvent(event);
+
+		// then
+		then(followRepository).should().findByFollowingWithFollower(mockFollowing);
+		then(notificationRepository).should().saveAll(anyList());
+		then(notificationWebSocketHandler).should(times(mockFollows.size()))
+				.sendMessageToUser(anyLong(), any(NotificationDetailResDto.class));
+	}
+
+}

--- a/back/src/test/java/dev/kyudong/back/notification/NotificationIntegrationTests.java
+++ b/back/src/test/java/dev/kyudong/back/notification/NotificationIntegrationTests.java
@@ -1,0 +1,161 @@
+package dev.kyudong.back.notification;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import dev.kyudong.back.common.jwt.JwtUtil;
+import dev.kyudong.back.notification.api.dto.res.NotificationResDto;
+import dev.kyudong.back.notification.domain.Notification;
+import dev.kyudong.back.notification.domain.NotificationType;
+import dev.kyudong.back.notification.repository.NotificationRepository;
+import dev.kyudong.back.post.domain.Post;
+import dev.kyudong.back.post.repository.PostRepository;
+import dev.kyudong.back.user.domain.User;
+import dev.kyudong.back.user.repository.UserRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpHeaders;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@Transactional
+@SpringBootTest
+@AutoConfigureMockMvc
+public class NotificationIntegrationTests {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Autowired
+	private ObjectMapper objectMapper;
+
+	@Autowired
+	private UserRepository userRepository;
+
+	@Autowired
+	private PostRepository postRepository;
+
+	@Autowired
+	private NotificationRepository notificationRepository;
+
+	@Autowired
+	private PasswordEncoder passwordEncoder;
+
+	@Autowired
+	private JwtUtil jwtUtil;
+
+	private User createTestUser(String username) {
+		User newUser = User.builder()
+				.username(username)
+				.rawPassword("password")
+				.encodedPassword(passwordEncoder.encode("password"))
+				.build();
+		return userRepository.save(newUser);
+	}
+
+	private Post createTestPost(User user) {
+		Post newPost = Post.builder()
+				.subject("Test")
+				.content("Hello World!")
+				.build();
+		user.addPost(newPost);
+		return postRepository.save(newPost);
+	}
+
+	private Notification createMockNotification(User receiver, User sender, String redirectUrl) {
+		Notification newNotification = Notification.builder()
+				.receiver(receiver)
+				.sender(sender)
+				.redirectUrl(redirectUrl)
+				.type(NotificationType.POST)
+				.build();
+		return notificationRepository.save(newNotification);
+	}
+
+	@Test
+	@DisplayName("알림 목록 조회")
+	void findNotifications() throws Exception {
+		// given
+		User receiver = createTestUser("receiver");
+		User sender = createTestUser("following");
+
+		Post post = createTestPost(sender);
+		createMockNotification(receiver, sender, "/post/" + post.getId());
+
+		// when
+		MvcResult result = mockMvc.perform(get("/api/v1/notification")
+								.header(HttpHeaders.AUTHORIZATION, "Bearer " + jwtUtil.generateToken(receiver))
+								.param("size", "10"))
+						.andExpect(status().isOk())
+						.andDo(print())
+						.andReturn();
+
+		// then
+		String responseBody = result.getResponse().getContentAsString();
+		NotificationResDto response = objectMapper.readValue(responseBody, NotificationResDto.class);
+		assertThat(response).isNotNull();
+		assertThat(response.content().get(0).redirectUrl()).isEqualTo("/post/" + post.getId());
+		assertThat(response.hasNext()).isFalse();
+
+		Optional<Notification> optionalNotification = notificationRepository.findById(response.content().get(0).id());
+		assertThat(optionalNotification).isPresent();
+	}
+
+	@Test
+	@DisplayName("알림 조회")
+	void readNotification() throws Exception {
+		// given
+		User receiver = createTestUser("receiver");
+		User sender = createTestUser("following");
+
+		Post post = createTestPost(sender);
+		Notification notification = createMockNotification(receiver, sender, "/post/" + post.getId());
+
+		// when
+		mockMvc.perform(patch("/api/v1/notification/{notificationId}", notification.getId())
+						.header(HttpHeaders.AUTHORIZATION, "Bearer " + jwtUtil.generateToken(receiver)))
+				.andExpect(status().isNoContent())
+				.andDo(print())
+				.andReturn();
+
+		// then
+		Optional<Notification> optionalNotification = notificationRepository.findById(notification.getId());
+		assertThat(optionalNotification).isPresent();
+
+		Notification savedNotification = optionalNotification.get();
+		assertThat(savedNotification.isRead()).isTrue();
+	}
+
+	@Test
+	@DisplayName("알림 삭제")
+	void deleteNotification() throws Exception {
+		// given
+		User receiver = createTestUser("receiver");
+		User sender = createTestUser("following");
+
+		Post post = createTestPost(sender);
+		Notification notification = createMockNotification(receiver, sender, "/post/" + post.getId());
+
+		// when
+		mockMvc.perform(delete("/api/v1/notification/{notificationId}", notification.getId())
+						.header(HttpHeaders.AUTHORIZATION, "Bearer " + jwtUtil.generateToken(receiver)))
+				.andExpect(status().isNoContent())
+				.andDo(print())
+				.andReturn();
+
+		// then
+		Optional<Notification> optionalNotification = notificationRepository.findById(notification.getId());
+		assertThat(optionalNotification).isNotPresent();
+	}
+
+}

--- a/back/src/test/java/dev/kyudong/back/notification/NotificationScedulerTests.java
+++ b/back/src/test/java/dev/kyudong/back/notification/NotificationScedulerTests.java
@@ -1,0 +1,73 @@
+package dev.kyudong.back.notification;
+
+import dev.kyudong.back.notification.domain.Notification;
+import dev.kyudong.back.notification.domain.NotificationType;
+import dev.kyudong.back.notification.repository.NotificationRepository;
+import dev.kyudong.back.notification.scheduler.NotificationScheduler;
+import dev.kyudong.back.user.domain.User;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.mockito.BDDMockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class NotificationScedulerTests {
+
+	@Mock
+	private NotificationRepository notificationRepository;
+
+	@InjectMocks
+	private NotificationScheduler notificationScheduler;
+
+	private static User makeMockUser(String username, Long id) {
+		User mockUser = User.builder()
+				.username(username)
+				.rawPassword("passWord")
+				.encodedPassword("passWord")
+				.build();
+		ReflectionTestUtils.setField(mockUser, "id", id);
+		return mockUser;
+	}
+
+	private static Notification makeMockNotification(User receiver, User sender, Long id) {
+		Notification mockNotification = Notification.builder()
+				.receiver(receiver)
+				.sender(sender)
+				.redirectUrl("/example")
+				.type(NotificationType.POST)
+				.build();
+		ReflectionTestUtils.setField(mockNotification, "id", id);
+		ReflectionTestUtils.setField(mockNotification, "createdAt", Instant.now().minus(366, ChronoUnit.DAYS));
+		return mockNotification;
+	}
+
+	@Test
+	void cleanupOrphanedNotification_success() {
+		// given
+		User receiver = makeMockUser("dkdkqwn", 1L);
+		User sender = makeMockUser("wqqwq", 2L);
+
+		List<Notification> oldNotifications = Arrays.asList(
+				makeMockNotification(receiver, sender, 1L),
+				makeMockNotification(receiver, sender, 2L)
+		);
+		given(notificationRepository.findByCreatedAtBefore(any(Instant.class)))
+				.willReturn(oldNotifications);
+
+		// when
+		notificationScheduler.cleanupOrphanedNotification();
+
+		// then
+		then(notificationRepository).should().deleteAll(oldNotifications);
+	}
+
+}

--- a/back/src/test/java/dev/kyudong/back/notification/NotificationServiceTests.java
+++ b/back/src/test/java/dev/kyudong/back/notification/NotificationServiceTests.java
@@ -1,0 +1,189 @@
+package dev.kyudong.back.notification;
+
+import dev.kyudong.back.notification.api.dto.res.NotificationResDto;
+import dev.kyudong.back.notification.domain.Notification;
+import dev.kyudong.back.notification.domain.NotificationType;
+import dev.kyudong.back.notification.exception.NotificationNotFoundException;
+import dev.kyudong.back.notification.repository.NotificationRepository;
+import dev.kyudong.back.notification.service.NotificationService;
+import dev.kyudong.back.user.domain.User;
+import dev.kyudong.back.user.repository.UserRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+@ExtendWith(MockitoExtension.class)
+public class NotificationServiceTests {
+
+	@Mock
+	private UserRepository userRepository;
+
+	@Mock
+	private NotificationRepository notificationRepository;
+
+	@SuppressWarnings("unused")
+	@Mock
+	private ApplicationEventPublisher applicationEventPublisher;
+
+	@InjectMocks
+	private NotificationService notificationService;
+
+	private static User makeMockUser(String username, Long id) {
+		User mockUser = User.builder()
+				.username(username)
+				.rawPassword("passWord")
+				.encodedPassword("passWord")
+				.build();
+		ReflectionTestUtils.setField(mockUser, "id", id);
+		return mockUser;
+	}
+
+	private static Notification makeMockNotification(User receiver, User sender, String redirectUrl, Long id) {
+		Notification mockNotification = Notification.builder()
+				.receiver(receiver)
+				.sender(sender)
+				.redirectUrl(redirectUrl)
+				.type(NotificationType.POST)
+				.build();
+		ReflectionTestUtils.setField(mockNotification, "id", id);
+		return mockNotification;
+	}
+
+	@Test
+	@DisplayName("알림 목록 조회 - 성공: 첫 조회")
+	void findNotification_success() {
+		// given
+		final Long receiverId = 1L;
+		User mockReceivcer = makeMockUser("sdfdsz", receiverId);
+		given(userRepository.getReferenceById(mockReceivcer.getId())).willReturn(mockReceivcer);
+		User mockSender = makeMockUser("dkxzzz", 2L);
+
+		PageRequest pageRequest = PageRequest.of(0, 10);
+		Notification mockNotification1 = makeMockNotification(mockReceivcer, mockSender, "/post/1", 1L);
+		Notification mockNotification2 = makeMockNotification(mockReceivcer, mockSender, "/post/2", 2L);
+		Slice<Notification> mockSliceNotification = new SliceImpl<>(
+				List.of(mockNotification1, mockNotification2), pageRequest, false
+		);
+		given(notificationRepository.findNotificationByReceiver(mockReceivcer, pageRequest))
+				.willReturn(mockSliceNotification);
+
+		// when
+		NotificationResDto response = notificationService
+				.findNotifications(receiverId, null, 10);
+
+		// then
+		assertThat(response).isNotNull();
+		assertThat(response.hasNext()).isEqualTo(false);
+		assertThat(response.lastNotificationId()).isNull();
+		assertThat(response.content().get(0).redirectUrl()).isEqualTo("/post/1");
+		then(userRepository).should().getReferenceById(receiverId);
+		then(notificationRepository).should().findNotificationByReceiver(mockReceivcer, pageRequest);
+	}
+
+	@Test
+	@DisplayName("알림 목록 조회 - 성공: 커서를 이용한 조회")
+	void findNotification_success_withCursor() {
+		// given
+		final Long receiverId = 1L;
+		User mockReceivcer = makeMockUser("sdfdsz", receiverId);
+		given(userRepository.getReferenceById(mockReceivcer.getId())).willReturn(mockReceivcer);
+		User mockSender = makeMockUser("dkxzzz", 2L);
+
+		PageRequest pageRequest = PageRequest.of(0, 10);
+		Notification mockNotification = makeMockNotification(mockReceivcer, mockSender, "/post/1", 1L);
+		Slice<Notification> mockSliceNotification = new SliceImpl<>(
+				List.of(mockNotification), pageRequest, true
+		);
+		given(notificationRepository.findNotificationByReceiver(mockReceivcer, 2L, pageRequest))
+				.willReturn(mockSliceNotification);
+
+		// when
+		NotificationResDto response = notificationService
+				.findNotifications(receiverId, 2L, 10);
+
+		// then
+		assertThat(response).isNotNull();
+		assertThat(response.hasNext()).isEqualTo(true);
+		assertThat(response.lastNotificationId()).isEqualTo(1L);
+		assertThat(response.content().get(0).redirectUrl()).isEqualTo("/post/1");
+		then(userRepository).should().getReferenceById(receiverId);
+		then(notificationRepository).should().findNotificationByReceiver(mockReceivcer, 2L, pageRequest);
+	}
+
+	@Test
+	@DisplayName("알림 조회 - 성공")
+	void readNotification_success() {
+		// given
+		final Long receiverId = 1L;
+		User mockReceivcer = makeMockUser("sdfdsz", receiverId);
+		given(userRepository.getReferenceById(mockReceivcer.getId())).willReturn(mockReceivcer);
+
+		final Long notificationId = 1L;
+		User mockSender = makeMockUser("dkxzzz", 2L);
+		Notification mockNotification = makeMockNotification(mockReceivcer, mockSender, "/post/1", notificationId);
+		given(notificationRepository.findByIdAndReceiver(notificationId, mockReceivcer)).willReturn(Optional.of(mockNotification));
+
+		// when
+		notificationService.readNotification(receiverId, notificationId);
+
+		// then
+		assertThat(mockNotification.isRead()).isTrue();
+		then(userRepository).should().getReferenceById(receiverId);
+		then(notificationRepository).should().findByIdAndReceiver(notificationId, mockReceivcer);
+	}
+
+	@Test
+	@DisplayName("알림 조회 - 실패: 알림을 찾을 수 없습니다")
+	void readNotification_fail_notificationNotFound() {
+		// given
+		final Long receiverId = 1L;
+		User mockReceivcer = makeMockUser("sdfdsz", receiverId);
+		given(userRepository.getReferenceById(mockReceivcer.getId())).willReturn(mockReceivcer);
+
+		final Long notificationId = 1L;
+		given(notificationRepository.findByIdAndReceiver(notificationId, mockReceivcer)).willReturn(Optional.empty());
+
+		// when & then
+		assertThatThrownBy(() -> notificationService.readNotification(receiverId, notificationId))
+				.isInstanceOf(NotificationNotFoundException.class);
+	}
+
+	@Test
+	@DisplayName("알림 삭제 - 성공")
+	void deleteNotification_success() {
+		// given
+		final Long receiverId = 1L;
+		User mockReceivcer = makeMockUser("sdfdsz", receiverId);
+		given(userRepository.getReferenceById(mockReceivcer.getId())).willReturn(mockReceivcer);
+
+		final Long notificationId = 1L;
+		User mockSender = makeMockUser("dkxzzz", 2L);
+		Notification mockNotification = makeMockNotification(mockReceivcer, mockSender, "/post/1", notificationId);
+		given(notificationRepository.findByIdAndReceiver(notificationId, mockReceivcer)).willReturn(Optional.of(mockNotification));
+
+		// when
+		notificationService.readNotification(receiverId, notificationId);
+
+		// then
+		assertThat(mockNotification.isRead()).isTrue();
+		then(userRepository).should().getReferenceById(receiverId);
+		then(notificationRepository).should().findByIdAndReceiver(notificationId, mockReceivcer);
+	}
+
+}


### PR DESCRIPTION

Notification:
- Notification 엔티티와 Controller, Service, Scheduler 등 기본 골격 구현
- GlobalExceptionHandler 에 파일관련 exception 추가
- 관련 단위 테스트 및 통합 테스트 코드 작성

Post:
- 알림 기능을 위해 게시글에 기능 추가

Chore:
- 알림 기능을 위해 웹소켓 라이브러리 추가