### PR TITLE
feat(chat): 채팅 도메인 기초 CRUD API 구현

### DIFF
--- a/back/build.gradle
+++ b/back/build.gradle
@@ -35,6 +35,7 @@ dependencies {
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'org.postgresql:postgresql'
+    runtimeOnly 'com.h2database:h2'
     annotationProcessor 'org.projectlombok:lombok'
     annotationProcessor "org.springframework.boot:spring-boot-configuration-processor"
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
@@ -45,4 +46,5 @@ dependencies {
 
 tasks.named('test') {
     useJUnitPlatform()
+    systemProperty "spring.profiles.active", "test"
 }

--- a/back/src/main/java/dev/kyudong/back/chat/api/ChatMemberApi.java
+++ b/back/src/main/java/dev/kyudong/back/chat/api/ChatMemberApi.java
@@ -1,0 +1,146 @@
+package dev.kyudong.back.chat.api;
+
+import dev.kyudong.back.chat.api.dto.req.ChatMemberInviteReqDto;
+import dev.kyudong.back.user.security.CustomUserPrincipal;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.constraints.Positive;
+import org.springframework.http.MediaType;
+import org.springframework.http.ProblemDetail;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+
+/**
+ * ChatMember API의 명세를 정의하는 인터페이스입니다.
+ * <p>
+ * 이 인터페이스의 메소드들은 실제 코드에서 직접 호출되지 않지만,
+ * Spring MVC 프레임워크에 의해 런타임 시 동적으로 구현체(Controller)와 연결되어 사용됩니다.
+ * <p>
+ * 따라서 IDE에서 '사용되지 않음(unused)'으로 잘못 분석할 수 있으므로,
+ * {@code @SuppressWarnings("unused")}를 사용하여 관련 경고를 억제합니다.
+ *
+ * @see org.springframework.web.bind.annotation.RestController
+ * @see SuppressWarnings
+ */
+@Tag(name = "ChatMember API", description = "채팅 사용자 API 명세서")
+public interface ChatMemberApi {
+
+	@SuppressWarnings("unused")
+	@Operation(summary = "사용자를 채팅방에 초대", description = "사용자를 채팅방에 초대 후 소켓으로 정보를 전송합니다")
+	@ApiResponses({
+			@ApiResponse(responseCode = "204", description = "사용자 초대 완료"),
+			@ApiResponse(responseCode = "404", description = "존재하지 않는 채팅방입니다",
+					content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+							schema = @Schema(implementation = ProblemDetail.class),
+							examples = @ExampleObject(value =
+									"""
+									{
+										"type": "about:blank",
+										"title": "Chat Room Not Found",
+										"status": 404,
+										"detail": "존재하지 않는 채팅방입니다: roomId=55",
+										"instance": "/api/v1/chatroom/1/members/1",
+										"timestamp": "2025-08-16T16:20:22.367368100Z"
+									}
+									"""
+							)
+					)
+			),
+			@ApiResponse(responseCode = "404", description = "초대자가 채팅방에 존재하지 않습니다",
+					content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+							schema = @Schema(implementation = ProblemDetail.class),
+							examples = @ExampleObject(value =
+									"""
+									{
+										"type": "about:blank",
+										"title": "Chat Member Not Found",
+										"status": 404,
+										"detail": "채팅방에 존재하지 않는 사용자입니다: userId=1, chatroomId=1",
+										"instance": "/api/v1/chatroom/1/members/1",
+										"timestamp": "2025-08-16T05:03:26.747698400Z"
+									}
+									"""
+							)
+					)
+			),
+			@ApiResponse(responseCode = "404", description = "초대할 사용자를 찾을 수 없습니다",
+					content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+							schema = @Schema(implementation = ProblemDetail.class),
+							examples = @ExampleObject(value =
+									"""
+									{
+										"type": "about:blank",
+										"title": "Users Not Found",
+										"status": 404,
+										"detail": "요청한 사용자 목록을 조회할 수 없습니다",
+										"instance": "/api/v1/chatroom/1/members/1",
+										"timestamp": "2025-08-16T16:20:22.367368100Z"
+									}
+									"""
+							)
+					)
+			),
+	})
+	ResponseEntity<Void> inviteChatRoom(
+			@Parameter(hidden = true, description = "로그인 사용자의 정보")
+			@AuthenticationPrincipal CustomUserPrincipal userPrincipal,
+			@Parameter(description = "초대할 채팅방의 아이디", required = true, example = "1")
+			@PathVariable @Positive Long roomId,
+			@RequestBody ChatMemberInviteReqDto requset
+	);
+
+	@SuppressWarnings("unused")
+	@Operation(summary = "채팅방을 탈퇴합니다", description = "사용자가 채팅방을 떠나고 소켓으로 탈퇴한 사용자 정보를 전달합니다")
+	@ApiResponses({
+			@ApiResponse(responseCode = "204", description = "선택한 채팅방을 떠납니다"),
+			@ApiResponse(responseCode = "404", description = "존재하지 않는 채팅방입니다",
+					content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+							schema = @Schema(implementation = ProblemDetail.class),
+							examples = @ExampleObject(value =
+									"""
+									{
+										"type": "about:blank",
+										"title": "Chat Room Not Found",
+										"status": 404,
+										"detail": "존재하지 않는 채팅방입니다: roomId=55",
+										"instance": "/api/v1/chatroom/1/members/1",
+										"timestamp": "2025-08-16T16:20:22.367368100Z"
+									}
+									"""
+							)
+					)
+			),
+			@ApiResponse(responseCode = "404", description = "초대자가 채팅방에 존재하지 않습니다",
+					content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+							schema = @Schema(implementation = ProblemDetail.class),
+							examples = @ExampleObject(value =
+									"""
+									{
+										"type": "about:blank",
+										"title": "Chat Member Not Found",
+										"status": 404,
+										"detail": "채팅방에 존재하지 않는 사용자입니다: roomId=1, leaveUserId=1",
+										"instance": "/api/v1/chatroom/1/members/me",
+										"timestamp": "2025-08-16T05:03:26.747698400Z"
+									}
+									"""
+							)
+					)
+			)
+	})
+	ResponseEntity<Void> leaveChatRoom(
+			@Parameter(hidden = true, description = "로그인 사용자의 정보")
+			@AuthenticationPrincipal CustomUserPrincipal userPrincipal,
+			@Parameter(description = "탈퇴할 채팅방의 아이디", required = true, example = "1")
+			@PathVariable @Positive Long roomId
+	);
+
+}

--- a/back/src/main/java/dev/kyudong/back/chat/api/ChatMemberController.java
+++ b/back/src/main/java/dev/kyudong/back/chat/api/ChatMemberController.java
@@ -1,0 +1,38 @@
+package dev.kyudong.back.chat.api;
+
+import dev.kyudong.back.chat.api.dto.req.ChatMemberInviteReqDto;
+import dev.kyudong.back.chat.service.ChatMemberService;
+import dev.kyudong.back.user.security.CustomUserPrincipal;
+import jakarta.validation.constraints.Positive;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/chatroom/{roomId}/members")
+public class ChatMemberController implements ChatMemberApi {
+
+	private final ChatMemberService chatMemberService;
+
+	@PostMapping
+	public ResponseEntity<Void> inviteChatRoom(
+			@AuthenticationPrincipal CustomUserPrincipal userPrincipal,
+			@PathVariable @Positive Long roomId,
+			@RequestBody ChatMemberInviteReqDto requset
+	) {
+		chatMemberService.inviteChatRoom(userPrincipal.getId(), roomId, requset);
+		return ResponseEntity.noContent().build();
+	}
+
+	@DeleteMapping("/me")
+	public ResponseEntity<Void> leaveChatRoom(
+			@AuthenticationPrincipal CustomUserPrincipal userPrincipal,
+			@PathVariable @Positive Long roomId
+	) {
+		chatMemberService.leaveChatRoom(roomId, userPrincipal.getId());
+		return ResponseEntity.noContent().build();
+	}
+
+}

--- a/back/src/main/java/dev/kyudong/back/chat/api/ChatMessageApi.java
+++ b/back/src/main/java/dev/kyudong/back/chat/api/ChatMessageApi.java
@@ -1,0 +1,190 @@
+package dev.kyudong.back.chat.api;
+
+import dev.kyudong.back.chat.api.dto.req.ChatMessageCreateReqDto;
+import dev.kyudong.back.chat.api.dto.res.ChatMessageResDto;
+import dev.kyudong.back.feed.api.dto.res.FeedDetailResDto;
+import dev.kyudong.back.user.security.CustomUserPrincipal;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.constraints.Positive;
+import org.springframework.http.MediaType;
+import org.springframework.http.ProblemDetail;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import java.time.Instant;
+
+/**
+ * ChatMessage API의 명세를 정의하는 인터페이스입니다.
+ * <p>
+ * 이 인터페이스의 메소드들은 실제 코드에서 직접 호출되지 않지만,
+ * Spring MVC 프레임워크에 의해 런타임 시 동적으로 구현체(Controller)와 연결되어 사용됩니다.
+ * <p>
+ * 따라서 IDE에서 '사용되지 않음(unused)'으로 잘못 분석할 수 있으므로,
+ * {@code @SuppressWarnings("unused")}를 사용하여 관련 경고를 억제합니다.
+ *
+ * @see org.springframework.web.bind.annotation.RestController
+ * @see SuppressWarnings
+ */
+@Tag(name = "ChatMessage API", description = "채팅 메시지 API 명세서")
+public interface ChatMessageApi {
+
+	@SuppressWarnings("unused")
+	@Operation(summary = "채팅 메시지 조회", description = "채팅방의 메시지를 조회합니다")
+	@ApiResponses({
+			@ApiResponse(responseCode = "200", description = "채팅 메시지 조회 성공",
+					content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+							schema = @Schema(implementation = FeedDetailResDto.class),
+							examples = @ExampleObject(value =
+									"""
+									{
+									  "cursorId": 1,
+									  "cursorTime": "2025-08-22T15:34:36.089587",
+									  "hasNext": false,
+									  "content": [
+										{
+										  "messageId": 96,
+										  "senderId": 279,
+										  "content": "게시글본문입니다",
+										  "messageType": "TEXT",
+										  "messageStatus": "ACTIVE",
+										  "createdAt": "2025-08-22T15:34:36.089587"
+										}
+									  ]
+									}
+									"""
+							)
+					)
+			),
+	})
+	ResponseEntity<ChatMessageResDto> findMessages(
+			@Parameter(description = "채팅방 아이디")
+			@PathVariable @Positive Long roomId,
+			@Parameter(name = "cursorId", description = "마지막 메시지 아이디")
+			@RequestParam(required = false) @Positive Long cursorId,
+			@Parameter(name = "cursorTime", description = "마지막 채팅방 메시지 시간")
+			@RequestParam(required = false) Instant cursorTime
+	);
+
+	@SuppressWarnings("unused")
+	@Operation(summary = "채팅 메시지 생성", description = "채팅 메시지를 생성하고 전송하고 소켓으로 전송합니다")
+	@ApiResponses({
+			@ApiResponse(responseCode = "204", description = "채팅 메시지 성공"),
+			@ApiResponse(responseCode = "404", description = "메시지를 전송한 방이 존재하지 않습니다",
+					content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+							schema = @Schema(implementation = ProblemDetail.class),
+							examples = @ExampleObject(value =
+									"""
+									{
+										"type": "about:blank",
+										"title": "Chat Room Not Found",
+										"status": 404,
+										"detail": "존재하지 않는 채팅방입니다: roomId=1",
+										"instance": "/api/v1/chatroom/1/message",
+										"timestamp": "2025-08-16T16:20:22.367368100Z"
+									}
+									"""
+							)
+					)
+			),
+			@ApiResponse(responseCode = "404", description = "메시지를 전송한 사용자가 채팅방에 없습니다",
+					content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+							schema = @Schema(implementation = ProblemDetail.class),
+							examples = @ExampleObject(value =
+									"""
+									{
+										"type": "about:blank",
+										"title": "Chat Member Not Found",
+										"status": 404,
+										"detail": "채팅방에 존재하지 않는 사용자입니다: userId=1, chatroomId=1",
+										"instance": "/api/v1/chatroom/1/message",
+										"timestamp": "2025-08-16T16:20:22.367368100Z"
+									}
+									"""
+							)
+					)
+			),
+	})
+	ResponseEntity<Void> createMessage(
+			@Parameter(hidden = true, description = "로그인 사용자의 정보")
+			@AuthenticationPrincipal CustomUserPrincipal userPrincipal,
+			@Parameter(description = "채팅방 아이디")
+			@PathVariable @Positive Long roomId,
+			@RequestBody ChatMessageCreateReqDto request
+	);
+
+	@SuppressWarnings("unused")
+	@Operation(summary = "메시지를 삭제", description = "선택한 메시지를 삭제하고 소켓으로 전송합니다")
+	@ApiResponses({
+			@ApiResponse(responseCode = "204", description = "선택한 메시지를 삭제합니다"),
+			@ApiResponse(responseCode = "404", description = "메시지를 전송한 방이 존재하지 않습니다",
+					content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+							schema = @Schema(implementation = ProblemDetail.class),
+							examples = @ExampleObject(value =
+									"""
+									{
+										"type": "about:blank",
+										"title": "Chat Room Not Found",
+										"status": 404,
+										"detail": "존재하지 않는 채팅방입니다: roomId=1",
+										"instance": "/api/v1/chatroom/1/message",
+										"timestamp": "2025-08-16T16:20:22.367368100Z"
+									}
+									"""
+							)
+					)
+			),
+			@ApiResponse(responseCode = "404", description = "메시지를 전송한 사용자가 채팅방에 없습니다",
+					content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+							schema = @Schema(implementation = ProblemDetail.class),
+							examples = @ExampleObject(value =
+									"""
+									{
+										"type": "about:blank",
+										"title": "Chat Member Not Found",
+										"status": 404,
+										"detail": "채팅방에 존재하지 않는 사용자입니다: userId=1, chatroomId=1",
+										"instance": "/api/v1/chatroom/1/message",
+										"timestamp": "2025-08-16T16:20:22.367368100Z"
+									}
+									"""
+							)
+					)
+			),
+			@ApiResponse(responseCode = "404", description = "삭제할 메시지를 찾을 수 없습니다",
+					content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+							schema = @Schema(implementation = ProblemDetail.class),
+							examples = @ExampleObject(value =
+									"""
+									{
+										"type": "about:blank",
+										"title": "Chat Message Not Found",
+										"status": 404,
+										"detail": "존재하지 않는 메시지입니다: messageId=1, chatroomId=1,
+										"instance": "/api/v1/chatroom/1/message/1",
+										"timestamp": "2025-08-16T16:20:22.367368100Z"
+									}
+									"""
+							)
+					)
+			),
+	})
+	ResponseEntity<Void> deleteMessage(
+			@Parameter(hidden = true, description = "로그인 사용자의 정보")
+			@AuthenticationPrincipal CustomUserPrincipal userPrincipal,
+			@Parameter(description = "채팅방 아이디")
+			@PathVariable @Positive Long roomId,
+			@Parameter(description = "삭제할 메시지 아이디")
+			@PathVariable @Positive Long messageId
+	);
+
+}

--- a/back/src/main/java/dev/kyudong/back/chat/api/ChatMessageController.java
+++ b/back/src/main/java/dev/kyudong/back/chat/api/ChatMessageController.java
@@ -1,0 +1,54 @@
+package dev.kyudong.back.chat.api;
+
+import dev.kyudong.back.chat.api.dto.req.ChatMessageCreateReqDto;
+import dev.kyudong.back.chat.api.dto.res.ChatMessageResDto;
+import dev.kyudong.back.chat.service.ChatMessageService;
+import dev.kyudong.back.user.security.CustomUserPrincipal;
+import jakarta.validation.constraints.Positive;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.Instant;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/chatroom/{roomId}/message")
+public class ChatMessageController implements ChatMessageApi {
+
+	private final ChatMessageService chatMessageService;
+
+	@Override
+	@GetMapping
+	public ResponseEntity<ChatMessageResDto> findMessages(
+			@PathVariable @Positive Long roomId,
+			@RequestParam(required = false) @Positive Long cursorId,
+			@RequestParam(required = false) Instant cursorTime
+	) {
+		return ResponseEntity.ok(chatMessageService.findMessages(roomId, cursorId, cursorTime));
+	}
+
+	@Override
+	@PostMapping
+	public ResponseEntity<Void> createMessage(
+			@AuthenticationPrincipal CustomUserPrincipal userPrincipal,
+			@PathVariable @Positive Long roomId,
+			@RequestBody ChatMessageCreateReqDto request
+	) {
+		chatMessageService.createMessage(userPrincipal.getId(), roomId, request);
+		return ResponseEntity.noContent().build();
+	}
+
+	@Override
+	@DeleteMapping("{messageId}")
+	public ResponseEntity<Void> deleteMessage(
+			@AuthenticationPrincipal CustomUserPrincipal userPrincipal,
+			@PathVariable @Positive Long roomId,
+			@PathVariable @Positive Long messageId
+	) {
+		chatMessageService.deleteMessage(userPrincipal.getId(), roomId, messageId);
+		return ResponseEntity.noContent().build();
+	}
+
+}

--- a/back/src/main/java/dev/kyudong/back/chat/api/ChatRoomApi.java
+++ b/back/src/main/java/dev/kyudong/back/chat/api/ChatRoomApi.java
@@ -1,0 +1,127 @@
+package dev.kyudong.back.chat.api;
+
+import dev.kyudong.back.chat.api.dto.req.ChatRoomCreateReqDto;
+import dev.kyudong.back.chat.api.dto.res.ChatRoomCreateResDto;
+import dev.kyudong.back.chat.api.dto.res.ChatRoomResDto;
+import dev.kyudong.back.notification.api.dto.res.NotificationResDto;
+import dev.kyudong.back.user.security.CustomUserPrincipal;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.headers.Header;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.constraints.Positive;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.MediaType;
+import org.springframework.http.ProblemDetail;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import java.time.Instant;
+
+/**
+ * ChatRoomApi API의 명세를 정의하는 인터페이스입니다.
+ * <p>
+ * 이 인터페이스의 메소드들은 실제 코드에서 직접 호출되지 않지만,
+ * Spring MVC 프레임워크에 의해 런타임 시 동적으로 구현체(Controller)와 연결되어 사용됩니다.
+ * <p>
+ * 따라서 IDE에서 '사용되지 않음(unused)'으로 잘못 분석할 수 있으므로,
+ * {@code @SuppressWarnings("unused")}를 사용하여 관련 경고를 억제합니다.
+ *
+ * @see org.springframework.web.bind.annotation.RestController
+ * @see java.lang.SuppressWarnings
+ */
+@Tag(name = "ChatRoomApi API", description = "채팅방 API 명세서")
+public interface ChatRoomApi {
+
+	@SuppressWarnings("unused")
+	@Operation(summary = "채팅방 목록 조회", description = "채팅방 목록을 조회합니다")
+	@ApiResponses({
+			@ApiResponse(responseCode = "200", description = "채팅방 목록 조회 완료",
+					content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+							schema = @Schema(implementation = NotificationResDto.class),
+							examples = @ExampleObject(value =
+									"""
+									{
+									  "lastChatroomId": 1,
+									  "lastActivityAt": "2025-08-16T16:20:22.367368100Z",
+									  "hasNext": false,
+									  "content": [
+										{
+										  "roomId": 1,
+										  "memberCount": 1
+										}
+									  ]
+									}
+									"""
+							)
+					)
+			)
+	})
+	ResponseEntity<ChatRoomResDto> findChatroom(
+			@Parameter(hidden = true, description = "로그인 사용자의 정보")
+			@AuthenticationPrincipal CustomUserPrincipal userPrincipal,
+			@Parameter(description = "마지막 조회한 채팅방 아이디")
+			@RequestParam(required = false) @Positive Long lastChatroomId,
+			@Parameter(description = "채팅방 마지막 활성화 시간")
+			@RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+			Instant cursorTime
+	);
+
+	@SuppressWarnings("unused")
+	@Operation(summary = "채팅방을 생성", description = "채팅방을 생성합니다")
+	@ApiResponses({
+			@ApiResponse(
+					responseCode = "201",
+					description = "채팅방 생성 완료",
+					headers = @Header(
+							name = "Location",
+							description = "생성된 채팅방의 리소스의 URI",
+							schema = @Schema(type = "string", format = "uri"),
+							examples = @ExampleObject(value = "/api/v1/chatroom/1")
+					),
+					content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+							schema = @Schema(implementation = NotificationResDto.class),
+							examples = @ExampleObject(value =
+									"""
+									{
+									  "roomId": 1,
+									  "memberCount": 1,
+									  "status": 'ACTIVE',
+									  "createdAt": "2025-08-16T16:20:22.367368100Z",
+									}
+									"""
+							)
+					)
+			),
+			@ApiResponse(responseCode = "404", description = "요청한 사용자 목록이 없습니다",
+					content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+							schema = @Schema(implementation = ProblemDetail.class),
+							examples = @ExampleObject(value =
+									"""
+									{
+										"type": "about:blank",
+										"title": "Users Not Found",
+										"status": 404,
+										"detail": "요청한 사용자 목록을 조회할 수 없습니다",
+										"instance": "/api/v1/chatroom",
+										"timestamp": "2025-08-16T16:20:22.367368100Z"
+									}
+									"""
+							)
+					)
+			),
+	})
+	ResponseEntity<ChatRoomCreateResDto> createChatroom(
+			@Parameter(hidden = true, description = "로그인 사용자의 정보")
+			@AuthenticationPrincipal CustomUserPrincipal userPrincipal,
+			@RequestBody ChatRoomCreateReqDto request
+	);
+
+}

--- a/back/src/main/java/dev/kyudong/back/chat/api/ChatRoomController.java
+++ b/back/src/main/java/dev/kyudong/back/chat/api/ChatRoomController.java
@@ -1,0 +1,49 @@
+package dev.kyudong.back.chat.api;
+
+import dev.kyudong.back.chat.api.dto.req.ChatRoomCreateReqDto;
+import dev.kyudong.back.chat.api.dto.res.ChatRoomCreateResDto;
+import dev.kyudong.back.chat.api.dto.res.ChatRoomResDto;
+import dev.kyudong.back.chat.service.ChatRoomService;
+import dev.kyudong.back.user.security.CustomUserPrincipal;
+import jakarta.validation.constraints.Positive;
+import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
+
+import java.net.URI;
+import java.time.Instant;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/chatroom")
+public class ChatRoomController implements ChatRoomApi {
+
+	private final ChatRoomService chatRoomService;
+
+	@Override
+	@GetMapping
+	public ResponseEntity<ChatRoomResDto> findChatroom(
+			@AuthenticationPrincipal CustomUserPrincipal userPrincipal,
+			@RequestParam(required = false) @Positive Long lastChatroomId,
+			@RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) Instant cursorTime) {
+		return ResponseEntity.ok(chatRoomService.findChatRooms(userPrincipal.getId(), lastChatroomId, cursorTime));
+	}
+
+	@Override
+	@PostMapping
+	public ResponseEntity<ChatRoomCreateResDto> createChatroom(
+			@AuthenticationPrincipal CustomUserPrincipal userPrincipal,
+			@RequestBody ChatRoomCreateReqDto request) {
+		ChatRoomCreateResDto chatRoomCreateResDto = chatRoomService.createChatRoom(userPrincipal.getId(), request);
+		URI uri = ServletUriComponentsBuilder.fromCurrentRequest()
+				.path("/{roomId}")
+				.buildAndExpand(chatRoomCreateResDto.roomId())
+				.toUri();
+		return ResponseEntity.created(uri).body(chatRoomCreateResDto);
+	}
+
+}
+

--- a/back/src/main/java/dev/kyudong/back/chat/api/dto/event/ChatMemberInviteEvent.java
+++ b/back/src/main/java/dev/kyudong/back/chat/api/dto/event/ChatMemberInviteEvent.java
@@ -1,0 +1,24 @@
+package dev.kyudong.back.chat.api.dto.event;
+
+import dev.kyudong.back.chat.domain.ChatMember;
+import dev.kyudong.back.chat.domain.ChatRoom;
+
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.Set;
+
+public record ChatMemberInviteEvent(
+		Long roomId,
+		Set<Long> existsUserIds,
+		Set<ChatMember> newMembers,
+		LocalDateTime lastActivityAt
+) {
+	public static ChatMemberInviteEvent of(ChatRoom chatRoom, Set<Long> existsUserIds, Set<ChatMember> newMembers) {
+		return new ChatMemberInviteEvent(
+				chatRoom.getId(),
+				existsUserIds,
+				newMembers,
+				LocalDateTime.ofInstant(chatRoom.getLastActivityAt(), ZoneOffset.UTC)
+		);
+	}
+}

--- a/back/src/main/java/dev/kyudong/back/chat/api/dto/event/ChatMemberLeftEvent.java
+++ b/back/src/main/java/dev/kyudong/back/chat/api/dto/event/ChatMemberLeftEvent.java
@@ -1,0 +1,15 @@
+package dev.kyudong.back.chat.api.dto.event;
+
+import dev.kyudong.back.chat.domain.ChatMember;
+
+import java.util.Set;
+
+public record ChatMemberLeftEvent(
+		Long roomId,
+		Long leaveUserId,
+		Set<ChatMember> members
+) {
+	public static ChatMemberLeftEvent of(Long roomId, Long leaveUserId, Set<ChatMember> members) {
+		return new ChatMemberLeftEvent(roomId, leaveUserId, members);
+	}
+}

--- a/back/src/main/java/dev/kyudong/back/chat/api/dto/event/ChatMessageCreateEvent.java
+++ b/back/src/main/java/dev/kyudong/back/chat/api/dto/event/ChatMessageCreateEvent.java
@@ -1,0 +1,34 @@
+package dev.kyudong.back.chat.api.dto.event;
+
+import dev.kyudong.back.chat.domain.*;
+import dev.kyudong.back.user.domain.User;
+
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.Set;
+
+public record ChatMessageCreateEvent(
+		Long messageId,
+		Long roomId,
+		Long senderId,
+		String senderUsername,
+		String content,
+		MessageType messageType,
+		MessageStatus messageStatus,
+		LocalDateTime createdAt,
+		Set<ChatMember> members
+) {
+	public static ChatMessageCreateEvent of(ChatMessage message, ChatRoom room, User sender) {
+		return new ChatMessageCreateEvent(
+			message.getId(),
+			room.getId(),
+			sender.getId(),
+			sender.getUsername(),
+			message.getContent(),
+			message.getMessageType(),
+			message.getMessageStatus(),
+			LocalDateTime.ofInstant(message.getCreatedAt(), ZoneOffset.UTC),
+			room.getChatMembers()
+		);
+	}
+}

--- a/back/src/main/java/dev/kyudong/back/chat/api/dto/event/ChatMessageDeleteEvent.java
+++ b/back/src/main/java/dev/kyudong/back/chat/api/dto/event/ChatMessageDeleteEvent.java
@@ -1,0 +1,25 @@
+package dev.kyudong.back.chat.api.dto.event;
+
+import dev.kyudong.back.chat.domain.*;
+
+import java.util.Set;
+
+public record ChatMessageDeleteEvent(
+		Long roomId,
+		Long messageId,
+		Long userId,
+		MessageType messageType,
+		MessageStatus messageStatus,
+		Set<ChatMember> members
+) {
+	public static ChatMessageDeleteEvent of(ChatMessage message, ChatRoom room, Long userId) {
+		return new ChatMessageDeleteEvent(
+			message.getChatRoom().getId(),
+			message.getId(),
+			userId,
+			message.getMessageType(),
+			message.getMessageStatus(),
+			room.getChatMembers()
+		);
+	}
+}

--- a/back/src/main/java/dev/kyudong/back/chat/api/dto/event/ChatRoomCreateEvent.java
+++ b/back/src/main/java/dev/kyudong/back/chat/api/dto/event/ChatRoomCreateEvent.java
@@ -1,0 +1,22 @@
+package dev.kyudong.back.chat.api.dto.event;
+
+import dev.kyudong.back.chat.domain.ChatMember;
+import dev.kyudong.back.chat.domain.ChatRoom;
+
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.Set;
+
+public record ChatRoomCreateEvent(
+		Long roomId,
+		LocalDateTime createdAt,
+		Set<ChatMember> chatMembers
+) {
+	public static ChatRoomCreateEvent from(ChatRoom chatRoom) {
+		return new ChatRoomCreateEvent(
+				chatRoom.getId(),
+				LocalDateTime.ofInstant(chatRoom.getCreatedAt(), ZoneOffset.UTC),
+				chatRoom.getChatMembers()
+		);
+	}
+}

--- a/back/src/main/java/dev/kyudong/back/chat/api/dto/req/ChatMemberInviteReqDto.java
+++ b/back/src/main/java/dev/kyudong/back/chat/api/dto/req/ChatMemberInviteReqDto.java
@@ -1,0 +1,14 @@
+package dev.kyudong.back.chat.api.dto.req;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.Size;
+
+import java.util.Set;
+
+public record ChatMemberInviteReqDto(
+		@NotNull(message = "유저 아이디 목록은 필수입니다")
+		@Size(max = 30, message = "최대 30명까지 한 번에 초대 가능합니다")
+		Set<@NotNull(message = "사용자 이이디는 NULL이 올 수 없습니다") @Positive Long> userIds
+) {
+}

--- a/back/src/main/java/dev/kyudong/back/chat/api/dto/req/ChatMessageCreateReqDto.java
+++ b/back/src/main/java/dev/kyudong/back/chat/api/dto/req/ChatMessageCreateReqDto.java
@@ -1,0 +1,14 @@
+package dev.kyudong.back.chat.api.dto.req;
+
+import dev.kyudong.back.chat.domain.MessageType;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.NotNull;
+
+public record ChatMessageCreateReqDto(
+		@Max(value = 1000, message = "최대 콘텐츠 길이는 1000글자 입니다")
+		String content,
+
+		@NotNull(message = "메시지 유형은 필수입니다")
+		MessageType messageType
+) {
+}

--- a/back/src/main/java/dev/kyudong/back/chat/api/dto/req/ChatRoomCreateReqDto.java
+++ b/back/src/main/java/dev/kyudong/back/chat/api/dto/req/ChatRoomCreateReqDto.java
@@ -1,0 +1,16 @@
+package dev.kyudong.back.chat.api.dto.req;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+
+import java.util.Set;
+
+public record ChatRoomCreateReqDto(
+		@Max(value = 100, message = "채팅방 이름의 최대 길이는 100글자 입니다")
+		String roomname,
+
+		@NotNull(message = "유저 아이디 목록은 필수입니다")
+		Set<@NotNull(message = "사용자 이이디는 NULL이 올 수 없습니다") @Positive Long> userIds
+) {
+}

--- a/back/src/main/java/dev/kyudong/back/chat/api/dto/res/ChatMessageDetailResDto.java
+++ b/back/src/main/java/dev/kyudong/back/chat/api/dto/res/ChatMessageDetailResDto.java
@@ -1,0 +1,28 @@
+package dev.kyudong.back.chat.api.dto.res;
+
+import dev.kyudong.back.chat.domain.ChatMessage;
+import dev.kyudong.back.chat.domain.MessageStatus;
+import dev.kyudong.back.chat.domain.MessageType;
+
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+
+public record ChatMessageDetailResDto(
+		Long messageId,
+		Long senderId,
+		String content,
+		MessageType messageType,
+		MessageStatus messageStatus,
+		LocalDateTime createdAt
+) {
+	public static ChatMessageDetailResDto from(ChatMessage chatMessage) {
+		return new ChatMessageDetailResDto(
+				chatMessage.getId(),
+				chatMessage.getSender().getUser().getId(),
+				chatMessage.getContent(),
+				chatMessage.getMessageType(),
+				chatMessage.getMessageStatus(),
+				LocalDateTime.ofInstant(chatMessage.getCreatedAt(), ZoneOffset.UTC)
+		);
+	}
+}

--- a/back/src/main/java/dev/kyudong/back/chat/api/dto/res/ChatMessageResDto.java
+++ b/back/src/main/java/dev/kyudong/back/chat/api/dto/res/ChatMessageResDto.java
@@ -1,0 +1,32 @@
+package dev.kyudong.back.chat.api.dto.res;
+
+import dev.kyudong.back.chat.domain.ChatMessage;
+import org.springframework.data.domain.Slice;
+
+import java.time.Instant;
+import java.util.List;
+
+public record ChatMessageResDto(
+		Long cursorId,
+		Instant cursorTime,
+		boolean hasNext,
+		List<ChatMessageDetailResDto> content
+) {
+	public static ChatMessageResDto from(Slice<ChatMessage> chatMessages) {
+		List<ChatMessageDetailResDto> content = chatMessages.getContent().stream()
+				.map(ChatMessageDetailResDto::from)
+				.toList();
+
+		Long cursorId = null;
+		Instant cursorTime = null;
+		boolean hasNext = chatMessages.hasNext();
+
+		if (hasNext) {
+			ChatMessage lastroom = chatMessages.getContent().get(chatMessages.getContent().size() - 1);
+			cursorId = lastroom.getId();
+			cursorTime = lastroom.getCreatedAt();
+		}
+
+		return new ChatMessageResDto(cursorId, cursorTime, hasNext, content);
+	}
+}

--- a/back/src/main/java/dev/kyudong/back/chat/api/dto/res/ChatRoomCreateResDto.java
+++ b/back/src/main/java/dev/kyudong/back/chat/api/dto/res/ChatRoomCreateResDto.java
@@ -1,0 +1,23 @@
+package dev.kyudong.back.chat.api.dto.res;
+
+import dev.kyudong.back.chat.domain.ChatRoom;
+import dev.kyudong.back.chat.domain.RoomStatus;
+
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+
+public record ChatRoomCreateResDto(
+		Long roomId,
+		int memberCount,
+		RoomStatus status,
+		LocalDateTime createdAt
+) {
+	public static ChatRoomCreateResDto from(ChatRoom chatRoom) {
+		return new ChatRoomCreateResDto(
+				chatRoom.getId(),
+				chatRoom.getChatMembers().size(),
+				chatRoom.getStatus(),
+				LocalDateTime.ofInstant(chatRoom.getCreatedAt(), ZoneOffset.UTC)
+		);
+	}
+}

--- a/back/src/main/java/dev/kyudong/back/chat/api/dto/res/ChatRoomDetailResDto.java
+++ b/back/src/main/java/dev/kyudong/back/chat/api/dto/res/ChatRoomDetailResDto.java
@@ -1,0 +1,15 @@
+package dev.kyudong.back.chat.api.dto.res;
+
+import dev.kyudong.back.chat.domain.ChatRoom;
+
+public record ChatRoomDetailResDto(
+		Long roomId,
+		Integer memberCount
+) {
+	public static ChatRoomDetailResDto from(ChatRoom chatRoom) {
+		return new ChatRoomDetailResDto(
+				chatRoom.getId(),
+				chatRoom.getChatMembers().size()
+		);
+	}
+}

--- a/back/src/main/java/dev/kyudong/back/chat/api/dto/res/ChatRoomResDto.java
+++ b/back/src/main/java/dev/kyudong/back/chat/api/dto/res/ChatRoomResDto.java
@@ -1,0 +1,32 @@
+package dev.kyudong.back.chat.api.dto.res;
+
+import dev.kyudong.back.chat.domain.ChatRoom;
+import org.springframework.data.domain.Slice;
+
+import java.time.Instant;
+import java.util.List;
+
+public record ChatRoomResDto(
+		Long lastChatroomId,
+		Instant lastActivityAt,
+		boolean hasNext,
+		List<ChatRoomDetailResDto> content
+) {
+	public static ChatRoomResDto from(Slice<ChatRoom> chatrooms) {
+		List<ChatRoomDetailResDto> content = chatrooms.getContent().stream()
+				.map(ChatRoomDetailResDto::from)
+				.toList();
+
+		Long lastChatroomId = null;
+		Instant lastActivityAt = null;
+		boolean hasNext = chatrooms.hasNext();
+
+		if (hasNext) {
+			ChatRoom lastroom = chatrooms.getContent().get(chatrooms.getContent().size() - 1);
+			lastChatroomId = lastroom.getId();
+			lastActivityAt = lastroom.getLastActivityAt();
+		}
+
+		return new ChatRoomResDto(lastChatroomId, lastActivityAt, hasNext, content);
+	}
+}

--- a/back/src/main/java/dev/kyudong/back/chat/api/dto/ws/ChatDelMessageWsDto.java
+++ b/back/src/main/java/dev/kyudong/back/chat/api/dto/ws/ChatDelMessageWsDto.java
@@ -1,0 +1,23 @@
+package dev.kyudong.back.chat.api.dto.ws;
+
+import dev.kyudong.back.chat.api.dto.event.ChatMessageDeleteEvent;
+import dev.kyudong.back.chat.domain.MessageStatus;
+import dev.kyudong.back.chat.domain.MessageType;
+
+public record ChatDelMessageWsDto(
+		Long roomId,
+		Long messageId,
+		Long userId,
+		MessageType messageType,
+		MessageStatus messageStatus
+) {
+	public static ChatDelMessageWsDto from(ChatMessageDeleteEvent event) {
+		return new ChatDelMessageWsDto(
+				event.roomId(),
+				event.messageId(),
+				event.userId(),
+				event.messageType(),
+				event.messageStatus()
+		);
+	}
+}

--- a/back/src/main/java/dev/kyudong/back/chat/api/dto/ws/ChatMemberInviteWsDto.java
+++ b/back/src/main/java/dev/kyudong/back/chat/api/dto/ws/ChatMemberInviteWsDto.java
@@ -1,0 +1,20 @@
+package dev.kyudong.back.chat.api.dto.ws;
+
+import dev.kyudong.back.chat.api.dto.event.ChatMemberInviteEvent;
+import dev.kyudong.back.chat.domain.ChatMember;
+
+import java.time.LocalDateTime;
+
+public record ChatMemberInviteWsDto(
+		Long roomId,
+		String roomName,
+		LocalDateTime createdAt
+) {
+	public static ChatMemberInviteWsDto of(ChatMemberInviteEvent event, ChatMember member) {
+		return new ChatMemberInviteWsDto(
+				event.roomId(),
+				member.getRoomName(),
+				event.lastActivityAt()
+		);
+	}
+}

--- a/back/src/main/java/dev/kyudong/back/chat/api/dto/ws/ChatMemberLeftWsDto.java
+++ b/back/src/main/java/dev/kyudong/back/chat/api/dto/ws/ChatMemberLeftWsDto.java
@@ -1,0 +1,12 @@
+package dev.kyudong.back.chat.api.dto.ws;
+
+import dev.kyudong.back.chat.api.dto.event.ChatMemberLeftEvent;
+
+public record ChatMemberLeftWsDto(
+		Long roomId,
+		Long leaveUserId
+) {
+	public static ChatMemberLeftWsDto from(ChatMemberLeftEvent event) {
+		return new ChatMemberLeftWsDto(event.roomId(), event.leaveUserId());
+	}
+}

--- a/back/src/main/java/dev/kyudong/back/chat/api/dto/ws/ChatNewMemberWsDto.java
+++ b/back/src/main/java/dev/kyudong/back/chat/api/dto/ws/ChatNewMemberWsDto.java
@@ -1,0 +1,22 @@
+package dev.kyudong.back.chat.api.dto.ws;
+
+import dev.kyudong.back.chat.api.dto.event.ChatMemberInviteEvent;
+import dev.kyudong.back.chat.api.dto.ws.vo.ChatMemberDetailVO;
+import dev.kyudong.back.chat.domain.ChatMember;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record ChatNewMemberWsDto(
+		Long roomId,
+		List<ChatMemberDetailVO> memberList,
+		LocalDateTime lastActivityAt
+) {
+	public static ChatNewMemberWsDto from(ChatMemberInviteEvent event) {
+		List<ChatMemberDetailVO> memberList = event.newMembers().stream()
+																.map(ChatMember::getUser)
+																.map(ChatMemberDetailVO::from)
+																.toList();
+		return new ChatNewMemberWsDto(event.roomId(), memberList, event.lastActivityAt());
+	}
+}

--- a/back/src/main/java/dev/kyudong/back/chat/api/dto/ws/ChatNewMessageWsDto.java
+++ b/back/src/main/java/dev/kyudong/back/chat/api/dto/ws/ChatNewMessageWsDto.java
@@ -1,0 +1,31 @@
+package dev.kyudong.back.chat.api.dto.ws;
+
+import dev.kyudong.back.chat.api.dto.event.ChatMessageCreateEvent;
+import dev.kyudong.back.chat.domain.MessageStatus;
+import dev.kyudong.back.chat.domain.MessageType;
+
+import java.time.LocalDateTime;
+
+public record ChatNewMessageWsDto(
+		Long messageId,
+		Long roomId,
+		Long senderId,
+		String senderUsername,
+		String content,
+		MessageType messageType,
+		MessageStatus messageStatus,
+		LocalDateTime createdAt
+) {
+	public static ChatNewMessageWsDto from(ChatMessageCreateEvent event) {
+		return new ChatNewMessageWsDto(
+				event.messageId(),
+				event.roomId(),
+				event.senderId(),
+				event.senderUsername(),
+				event.content(),
+				event.messageType(),
+				event.messageStatus(),
+				event.createdAt()
+		);
+	}
+}

--- a/back/src/main/java/dev/kyudong/back/chat/api/dto/ws/ChatNewRoomWsDto.java
+++ b/back/src/main/java/dev/kyudong/back/chat/api/dto/ws/ChatNewRoomWsDto.java
@@ -1,0 +1,24 @@
+package dev.kyudong.back.chat.api.dto.ws;
+
+import dev.kyudong.back.chat.api.dto.event.ChatRoomCreateEvent;
+import dev.kyudong.back.chat.domain.ChatMember;
+
+import java.time.LocalDateTime;
+
+public record ChatNewRoomWsDto(
+		Long roomId,
+		String roomName,
+		Long userId,
+		String userName,
+		LocalDateTime createdAt
+) {
+	public static ChatNewRoomWsDto of(ChatRoomCreateEvent event, ChatMember member) {
+		return new ChatNewRoomWsDto(
+				event.roomId(),
+				member.getRoomName(),
+				member.getUser().getId(),
+				member.getUser().getUsername(),
+				event.createdAt()
+		);
+	}
+}

--- a/back/src/main/java/dev/kyudong/back/chat/api/dto/ws/vo/ChatMemberDetailVO.java
+++ b/back/src/main/java/dev/kyudong/back/chat/api/dto/ws/vo/ChatMemberDetailVO.java
@@ -1,0 +1,15 @@
+package dev.kyudong.back.chat.api.dto.ws.vo;
+
+import dev.kyudong.back.user.domain.User;
+
+public record ChatMemberDetailVO(
+		Long userId,
+		String userName
+) {
+	public static ChatMemberDetailVO from(User user) {
+		return new ChatMemberDetailVO(
+				user.getId(),
+				user.getUsername()
+		);
+	}
+}

--- a/back/src/main/java/dev/kyudong/back/chat/domain/ChatMember.java
+++ b/back/src/main/java/dev/kyudong/back/chat/domain/ChatMember.java
@@ -1,0 +1,92 @@
+package dev.kyudong.back.chat.domain;
+
+import dev.kyudong.back.user.domain.User;
+import jakarta.persistence.*;
+import lombok.*;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.Instant;
+import java.util.Objects;
+
+@Entity
+@Getter
+@ToString(exclude = {"chatRoom"})
+@Table(
+		name = "CHAT_MEMBERS",
+		uniqueConstraints = {
+				@UniqueConstraint(
+						name = "uk_chat_user_chatroom",
+						columnNames = {"CHAT_ROOM_ID", "USER_ID"}
+				)
+		}
+)
+@EntityListeners(AuditingEntityListener.class)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ChatMember {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "ID", updatable = false)
+	private Long id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "CHAT_ROOM_ID", nullable = false)
+	private ChatRoom chatRoom;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "USER_ID", nullable = false)
+	private User user;
+
+	@Column(name = "ROOM_NAME", nullable = false, length = 150)
+	private String roomName;
+
+	@Enumerated(EnumType.STRING)
+	@Column(name = "STATUS", nullable = false, length = 20)
+	private MemberStatus status;
+
+	@CreatedDate
+	@Column(name = "JOINED_AT", updatable = false)
+	private Instant joinedt;
+
+	@Builder
+	private ChatMember(ChatRoom chatRoom, User user, String roomName) {
+		this.chatRoom = chatRoom;
+		this.user = user;
+		this.roomName = roomName;
+		this.status = MemberStatus.JOINED;
+	}
+
+	public void leave() {
+		this.status = MemberStatus.LEFT;
+	}
+
+	public void block() {
+		this.status = MemberStatus.BLOCKED;
+	}
+
+	public void kick() {
+		this.status = MemberStatus.KICK;
+	}
+
+	public void updateRoomName(String roomName) {
+		this.roomName = roomName;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) return true;
+		if (o == null || getClass() != o.getClass()) return false;
+
+		ChatMember that = (ChatMember) o;
+
+		if (!Objects.equals(id, that.id)) return false;
+		return Objects.equals(user, that.user);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(chatRoom, user);
+	}
+
+}

--- a/back/src/main/java/dev/kyudong/back/chat/domain/ChatMessage.java
+++ b/back/src/main/java/dev/kyudong/back/chat/domain/ChatMessage.java
@@ -1,0 +1,74 @@
+package dev.kyudong.back.chat.domain;
+
+import dev.kyudong.back.file.domain.File;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.Instant;
+
+@Entity
+@Getter
+@Table(name = "CHAT_MESSAGES")
+@EntityListeners(AuditingEntityListener.class)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ChatMessage {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "ID", updatable = false)
+	private Long id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "CHAT_ROOM_ID", nullable = false)
+	private ChatRoom chatRoom;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "SENDER_ID", nullable = false)
+	private ChatMember sender;
+
+	@Column(length = 1000, nullable = false)
+	private String content;
+
+	@Enumerated(EnumType.STRING)
+	@Column(name = "MESSAGE_TYPE", nullable = false, length = 20)
+	private MessageType messageType;
+
+	@Enumerated(EnumType.STRING)
+	@Column(name = "MESSAGE_STATUS", nullable = false, length = 20)
+	private MessageStatus messageStatus;
+
+	@OneToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "FILE_ID")
+	private File file;
+
+	@CreatedDate
+	@Column(name = "CREATED_AT", updatable = false)
+	private Instant createdAt;
+
+	@Column(name = "DELETE_AT", updatable = false)
+	private Instant deleteAt;
+
+	@Builder
+	private ChatMessage(ChatMember sender, String content, MessageType messageType, File file) {
+		this.sender = sender;
+		this.content = content;
+		this.messageType = messageType;
+		this.messageStatus = MessageStatus.ACTIVE;
+		this.file = file;
+	}
+
+	public void associateChatRoom(ChatRoom chatRoom) {
+		this.chatRoom = chatRoom;
+	}
+
+	public void delete() {
+		this.messageStatus = MessageStatus.DELETED;
+		this.deleteAt = Instant.now();
+	}
+
+}

--- a/back/src/main/java/dev/kyudong/back/chat/domain/ChatRoom.java
+++ b/back/src/main/java/dev/kyudong/back/chat/domain/ChatRoom.java
@@ -1,0 +1,109 @@
+package dev.kyudong.back.chat.domain;
+
+import dev.kyudong.back.user.domain.User;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.BatchSize;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Entity
+@Getter
+@Table(name = "CHAT_ROOMS")
+@EntityListeners(AuditingEntityListener.class)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ChatRoom {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "ID", updatable = false)
+	private Long id;
+
+	@OneToMany(
+			fetch = FetchType.LAZY,
+			cascade = CascadeType.PERSIST,
+			mappedBy = "chatRoom"
+	)
+	private final Set<ChatMember> chatMembers = new HashSet<>();
+
+	@OneToMany(fetch = FetchType.LAZY, mappedBy = "chatRoom")
+	@BatchSize(size = 50)
+	private List<ChatMessage> chatMessages = new ArrayList<>();
+
+	@Enumerated(EnumType.STRING)
+	@Column(name = "STATUS", nullable = false, length = 20)
+	private RoomStatus status;
+
+	@CreatedDate
+	@Column(name = "CREATED_AT", updatable = false)
+	private Instant createdAt;
+
+	@LastModifiedDate
+	@Column(name = "MODIFIED_AT")
+	private Instant modifiedAt;
+
+	@Column(name = "LAST_ACTIVITY_AT")
+	private Instant lastActivityAt;
+
+	@Builder
+	private ChatRoom(List<User> initUserList) {
+		this.addNewMember(initUserList);
+		this.status = RoomStatus.ACTIVE;
+	}
+
+	public Set<ChatMember> addNewMember(List<User> newUserList) {
+		Set<ChatMember> newMembers = new HashSet<>();
+
+		newUserList.forEach(currentUser -> {
+			List<User> otherUsers = newUserList.stream()
+					.filter(user -> !user.equals(currentUser))
+					.toList();
+
+			String roomName;
+			if (otherUsers.isEmpty()) {
+				roomName = "나와의 대화";
+			} else if (otherUsers.size() == 1) {
+				roomName = otherUsers.get(0).getUsername();
+			} else {
+				roomName = otherUsers.stream()
+						.map(User::getUsername)
+						.limit(4)
+						.collect(Collectors.joining(", "))
+						.trim();
+			}
+
+			ChatMember chatMember = ChatMember.builder()
+					.chatRoom(this)
+					.user(currentUser)
+					.roomName(roomName)
+					.build();
+			this.chatMembers.add(chatMember);
+			newMembers.add(chatMember);
+		});
+
+		updateLastActivityAt();
+		return newMembers;
+	}
+
+	public void addMessage(@NonNull ChatMessage chatMessage) {
+		this.chatMessages.add(chatMessage);
+		chatMessage.associateChatRoom(this);
+		updateLastActivityAt();
+	}
+
+	/**
+	 * 채팅방의 활동일을 갱신합니다
+	 */
+	private void updateLastActivityAt() {
+		this.lastActivityAt = Instant.now();
+	}
+
+}

--- a/back/src/main/java/dev/kyudong/back/chat/domain/MemberStatus.java
+++ b/back/src/main/java/dev/kyudong/back/chat/domain/MemberStatus.java
@@ -1,0 +1,10 @@
+package dev.kyudong.back.chat.domain;
+
+public enum MemberStatus {
+
+	JOINED, 	// 참여중
+	LEFT,		// 나감
+	BLOCKED,	// 차단
+	KICK,		// 추방
+	
+}

--- a/back/src/main/java/dev/kyudong/back/chat/domain/MessageStatus.java
+++ b/back/src/main/java/dev/kyudong/back/chat/domain/MessageStatus.java
@@ -1,0 +1,8 @@
+package dev.kyudong.back.chat.domain;
+
+public enum MessageStatus {
+
+	ACTIVE,		// 정상
+	DELETED,	// 삭제됨
+
+}

--- a/back/src/main/java/dev/kyudong/back/chat/domain/MessageType.java
+++ b/back/src/main/java/dev/kyudong/back/chat/domain/MessageType.java
@@ -1,0 +1,10 @@
+package dev.kyudong.back.chat.domain;
+
+public enum MessageType {
+
+	TEXT,		// 텍스트만
+	IMAGE,		// 이미지
+	VIDEO,		// 영상
+	FILE,		// 파일첨부
+
+}

--- a/back/src/main/java/dev/kyudong/back/chat/domain/RoomStatus.java
+++ b/back/src/main/java/dev/kyudong/back/chat/domain/RoomStatus.java
@@ -1,0 +1,8 @@
+package dev.kyudong.back.chat.domain;
+
+public enum RoomStatus {
+
+	ACTIVE,		// 정상
+	DELETED,	// 삭제됨
+
+}

--- a/back/src/main/java/dev/kyudong/back/chat/event/ChatEventHandler.java
+++ b/back/src/main/java/dev/kyudong/back/chat/event/ChatEventHandler.java
@@ -1,0 +1,47 @@
+package dev.kyudong.back.chat.event;
+
+import dev.kyudong.back.chat.api.dto.event.*;
+
+public interface ChatEventHandler {
+
+	/**
+	 * 새로운 채팅 메시지가 생성되었다는 이벤트를 처리하며,
+	 * 해당 채팅방의 모든 참여자에게 웹소켓을 통해 메시지를 전송한다.
+	 * @see ChatMessageCreateEvent
+	 * @param event 메시지 생성
+	 */
+	void handleMessageCreate(ChatMessageCreateEvent event);
+
+	/**
+	 * 채팅 메시지가 삭제되었다는 이벤트를 처리하며,
+	 * 해당 채팅방의 모든 참여자에게 웹소켓을 통해 삭제된 메시지 상태를 전송한다.
+	 * @see ChatMessageDeleteEvent
+	 * @param event 메시지 삭제
+	 */
+	void handleMessageDelete(ChatMessageDeleteEvent event);
+
+	/**
+	 * 채팅방 생성 이벤트를 처리하며,
+	 * 초대된 사용자에게 웹소켓을 통해 채팅방 정보를 전송한다.
+	 * @see ChatRoomCreateEvent
+	 * @param event 채팅방 생성
+	 */
+	void handleRoomCreate(ChatRoomCreateEvent event);
+
+	/**
+	 * 채팅방에 사용자 초대 이벤트를 처리하며,
+	 * 초대된 사용자에게 웹소켓을 통해 채팅방 정보를 전송한다.
+	 * @see ChatMemberInviteEvent
+	 * @param event 초대된 사용자
+	 */
+	void handleMemberInvite(ChatMemberInviteEvent event);
+
+	/**
+	 * 채팅방에 사용자 탈퇴 이벤트를 처리하며,
+	 * 채티방의 사용자들에게 웹소켓을 통해 채팅방 정보를 전송한다.
+	 * @see ChatMemberLeftEvent
+	 * @param event 채팅방 탈퇴 사용자
+	 */
+	void handleMemberLeft(ChatMemberLeftEvent event);
+
+}

--- a/back/src/main/java/dev/kyudong/back/chat/event/ChatEventType.java
+++ b/back/src/main/java/dev/kyudong/back/chat/event/ChatEventType.java
@@ -1,0 +1,28 @@
+package dev.kyudong.back.chat.event;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+
+/**
+ * 웹 소켓과 채팅간의 이벤트를 정의합니다
+ */
+public enum ChatEventType {
+
+	NEW_MESSAGE("newMessage"),
+	DEL_MESSAGE("delMessage"),
+	NEW_CHAT_ROOM("newChatRoom"),
+	INVITE_NEW_MEMBER("inviteNewMember"),
+	NEW_MEMBER("newMember"),
+	LEFT_MEMBER("leftMember");
+
+	private final String detail;
+
+	ChatEventType(String deatil) {
+		this.detail = deatil;
+	}
+
+	@JsonValue
+	public String getDetail() {
+		return detail;
+	}
+
+}

--- a/back/src/main/java/dev/kyudong/back/chat/event/DefaultChatEventHandler.java
+++ b/back/src/main/java/dev/kyudong/back/chat/event/DefaultChatEventHandler.java
@@ -1,0 +1,123 @@
+package dev.kyudong.back.chat.event;
+
+import dev.kyudong.back.chat.api.dto.event.*;
+import dev.kyudong.back.chat.api.dto.ws.*;
+import dev.kyudong.back.chat.domain.ChatMember;
+import dev.kyudong.back.chat.domain.MemberStatus;
+import dev.kyudong.back.chat.websocket.ChatBroadCaster;
+import dev.kyudong.back.chat.websocket.ChatWebSocketMessage;
+import dev.kyudong.back.user.domain.User;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class DefaultChatEventHandler implements ChatEventHandler {
+
+	private final ChatBroadCaster chatBroadCaster;
+
+	@Override
+	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+	@Transactional(propagation = Propagation.REQUIRES_NEW)
+	public void handleMessageCreate(ChatMessageCreateEvent event) {
+		log.debug("채팅 메시지 생성 이벤트를 수신하였습니다: roomId={}", event.roomId());
+
+		ChatWebSocketMessage<ChatNewMessageWsDto> webSocketMessage =
+				ChatWebSocketMessage.of(ChatEventType.NEW_MESSAGE, ChatNewMessageWsDto.from(event));
+
+		Set<Long> joinUserIds = event.members().stream()
+				.filter(m -> m.getStatus() == MemberStatus.JOINED)
+				.map(ChatMember::getUser)
+				.map(User::getId)
+				.collect(Collectors.toSet());
+
+		chatBroadCaster.brodCastMessageToMembers(joinUserIds, webSocketMessage);
+		log.debug("채팅 메시지 생성 이벤트가 종료되었습니다");
+	}
+
+	@Override
+	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+	@Transactional(propagation = Propagation.REQUIRES_NEW)
+	public void handleMessageDelete(ChatMessageDeleteEvent event) {
+		log.debug("채팅 메시지 삭제 이벤트를 수신하였습니다: roomId={}", event.roomId());
+
+		ChatWebSocketMessage<ChatDelMessageWsDto> webSocketMessage =
+				ChatWebSocketMessage.of(ChatEventType.DEL_MESSAGE, ChatDelMessageWsDto.from(event));
+
+		Set<Long> joinUserIds = event.members().stream()
+				.filter(m -> m.getStatus() == MemberStatus.JOINED)
+				.map(ChatMember::getUser)
+				.map(User::getId)
+				.collect(Collectors.toSet());;
+
+		chatBroadCaster.brodCastMessageToMembers(joinUserIds, webSocketMessage);
+		log.debug("채팅 메시지 삭제 이벤트가 종료되었습니다");
+	}
+
+	@Override
+	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+	@Transactional(propagation = Propagation.REQUIRES_NEW)
+	public void handleRoomCreate(ChatRoomCreateEvent event) {
+		log.debug("채팅방 생성 이벤트를 수신하였습니다: roomId={}", event.roomId());
+
+		Map<Long, ChatWebSocketMessage<ChatNewRoomWsDto>> webSocketMessage = new HashMap<>();
+		event.chatMembers().forEach(member -> {
+			ChatNewRoomWsDto chatNewRoomWsDto = ChatNewRoomWsDto.of(event, member);
+			webSocketMessage.put(member.getId(), ChatWebSocketMessage.of(ChatEventType.NEW_CHAT_ROOM, chatNewRoomWsDto));
+		});
+
+		chatBroadCaster.brodCastIndividualMessages(webSocketMessage);
+		log.debug("채팅방 생성 이벤트가 종료되었습니다");
+	}
+
+	@Override
+	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+	@Transactional(propagation = Propagation.REQUIRES_NEW)
+	public void handleMemberInvite(ChatMemberInviteEvent event) {
+		log.debug("사용자 초대 이벤트를 수신하였습니다: roomId={}", event.roomId());
+
+		// 초대된 사용자들에게 메시지 전송
+		Map<Long, ChatWebSocketMessage<ChatMemberInviteWsDto>> webSocketInvidualMessage = new HashMap<>();
+		event.newMembers().forEach(member -> {
+			ChatMemberInviteWsDto chatNewRoomWsDto = ChatMemberInviteWsDto.of(event, member);
+			webSocketInvidualMessage.put(member.getUser().getId(), ChatWebSocketMessage.of(ChatEventType.INVITE_NEW_MEMBER, chatNewRoomWsDto));
+		});
+		chatBroadCaster.brodCastIndividualMessages(webSocketInvidualMessage);
+
+		// 방을 이용중인 사용자들에게 메시지 전송
+		ChatWebSocketMessage<ChatNewMemberWsDto> webSocketSameMessage =
+				ChatWebSocketMessage.of(ChatEventType.NEW_MEMBER, ChatNewMemberWsDto.from(event));
+		chatBroadCaster.brodCastMessageToMembers(event.existsUserIds(), webSocketSameMessage);
+		log.debug("사용자 초대 이벤트가 종료되었습니다");
+	}
+
+	@Override
+	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+	@Transactional(propagation = Propagation.REQUIRES_NEW)
+	public void handleMemberLeft(ChatMemberLeftEvent event) {
+		log.debug("채팅방 퇴장 이벤트를 수신하였습니다: roomId={}", event.roomId());
+
+		ChatWebSocketMessage<ChatMemberLeftWsDto> webSocketMessage =
+				ChatWebSocketMessage.of(ChatEventType.LEFT_MEMBER, ChatMemberLeftWsDto.from(event));
+
+		Set<Long> joinUserIds = event.members().stream()
+				.filter(m -> m.getStatus() == MemberStatus.JOINED)
+				.map(ChatMember::getUser)
+				.map(User::getId)
+				.filter(userId -> !event.leaveUserId().equals(userId))
+				.collect(Collectors.toSet());;
+
+		chatBroadCaster.brodCastMessageToMembers(joinUserIds, webSocketMessage);
+		log.debug("채팅방 퇴장 이벤트가 종료되었습니다");
+	}
+
+}

--- a/back/src/main/java/dev/kyudong/back/chat/exception/ChatMemberExistsException.java
+++ b/back/src/main/java/dev/kyudong/back/chat/exception/ChatMemberExistsException.java
@@ -1,0 +1,7 @@
+package dev.kyudong.back.chat.exception;
+
+public class ChatMemberExistsException extends RuntimeException {
+	public ChatMemberExistsException(Long userId) {
+		super("이미 채팅방에 초대된 사용자입니다: userId=" + userId);
+	}
+}

--- a/back/src/main/java/dev/kyudong/back/chat/exception/ChatMemberNotFoundException.java
+++ b/back/src/main/java/dev/kyudong/back/chat/exception/ChatMemberNotFoundException.java
@@ -1,0 +1,7 @@
+package dev.kyudong.back.chat.exception;
+
+public class ChatMemberNotFoundException extends RuntimeException {
+	public ChatMemberNotFoundException(Long userId, Long chatroomId) {
+		super(String.format("채팅방에 존재하지 않는 사용자입니다: userId=%d, chatroomId=%d", userId, chatroomId));
+	}
+}

--- a/back/src/main/java/dev/kyudong/back/chat/exception/ChatMessageNotFoundException.java
+++ b/back/src/main/java/dev/kyudong/back/chat/exception/ChatMessageNotFoundException.java
@@ -1,0 +1,7 @@
+package dev.kyudong.back.chat.exception;
+
+public class ChatMessageNotFoundException extends RuntimeException {
+	public ChatMessageNotFoundException(Long messageId, Long chatroomId) {
+		super(String.format("존재하지 않는 메시지입니다: messageId=%d, chatroomId=%d", messageId, chatroomId));
+	}
+}

--- a/back/src/main/java/dev/kyudong/back/chat/exception/ChatRoomNotFoundException.java
+++ b/back/src/main/java/dev/kyudong/back/chat/exception/ChatRoomNotFoundException.java
@@ -1,0 +1,7 @@
+package dev.kyudong.back.chat.exception;
+
+public class ChatRoomNotFoundException extends RuntimeException {
+	public ChatRoomNotFoundException(Long chatRoomId) {
+		super("존재하지 않는 채팅방입니다: chatRoomId=" + chatRoomId);
+	}
+}

--- a/back/src/main/java/dev/kyudong/back/chat/repository/ChatMemberRepository.java
+++ b/back/src/main/java/dev/kyudong/back/chat/repository/ChatMemberRepository.java
@@ -1,0 +1,31 @@
+package dev.kyudong.back.chat.repository;
+
+import dev.kyudong.back.chat.domain.ChatMember;
+import dev.kyudong.back.chat.domain.ChatRoom;
+import dev.kyudong.back.chat.domain.MemberStatus;
+import dev.kyudong.back.user.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
+import java.util.Set;
+
+public interface ChatMemberRepository extends JpaRepository<ChatMember, Long> {
+
+	@Query("""
+			SELECT cm.user.id
+			FROM ChatMember cm
+			WHERE cm.chatRoom = :chatRoom
+			AND cm.user.id IN :userIds
+			AND cm.status = :status
+	""")
+	Set<Long> findExistsMemberUserIds(
+			@Param("userIds") Set<Long> userIds,
+			@Param("chatRoom") ChatRoom chatRoom,
+			@Param("status") MemberStatus status
+	);
+
+	Optional<ChatMember> findByUserAndChatRoom(User leaveUser, ChatRoom chatRoom);
+
+}

--- a/back/src/main/java/dev/kyudong/back/chat/repository/ChatMessageRepository.java
+++ b/back/src/main/java/dev/kyudong/back/chat/repository/ChatMessageRepository.java
@@ -1,0 +1,41 @@
+package dev.kyudong.back.chat.repository;
+
+import dev.kyudong.back.chat.domain.ChatMember;
+import dev.kyudong.back.chat.domain.ChatMessage;
+import dev.kyudong.back.chat.domain.ChatRoom;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.Instant;
+import java.util.Optional;
+
+public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> {
+
+	Optional<ChatMessage> findByIdAndChatRoomAndSender(Long messageId, ChatRoom chatRoom, ChatMember sender);
+
+	@Query("""
+			SELECT cm
+			FROM ChatMessage cm
+			WHERE cm.chatRoom.id = :roomId
+			ORDER BY cm.createdAt DESC, cm.id DESC
+	""")
+	Slice<ChatMessage> findChatMessage(@Param("roomId") Long roomId, PageRequest pageRequest);
+
+	@Query("""
+			SELECT cm
+			FROM ChatMessage cm
+			WHERE cm.chatRoom.id = :roomId
+			AND (cm.createdAt < :cursorTime OR (cm.createdAt = :cursorTime AND cm.id = :cursorId))
+			ORDER BY cm.createdAt DESC, cm.id DESC
+	""")
+	Slice<ChatMessage> findChatMessageByCursorTime(
+			@Param("roomId") Long roomId,
+			@Param("cursorId") Long cursorId,
+			@Param("cursorTime") Instant cursorTime,
+			PageRequest pageRequest
+	);
+
+}

--- a/back/src/main/java/dev/kyudong/back/chat/repository/ChatRoomRepository.java
+++ b/back/src/main/java/dev/kyudong/back/chat/repository/ChatRoomRepository.java
@@ -1,0 +1,67 @@
+package dev.kyudong.back.chat.repository;
+
+import dev.kyudong.back.chat.domain.ChatRoom;
+import dev.kyudong.back.chat.domain.RoomStatus;
+import dev.kyudong.back.user.domain.User;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+
+public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
+
+	@Query("""
+			SELECT c
+			FROM ChatRoom c
+			JOIN FETCH c.chatMembers cm
+			WHERE cm.user = :user
+			AND c.status = 'ACTIVE'
+			AND (c.lastActivityAt < :cursorTime OR (c.lastActivityAt = :cursorTime AND c.id < :lastChatroomId))
+			ORDER BY c.lastActivityAt DESC, c.id DESC
+	""")
+	Slice<ChatRoom> findChatRooomsByMember(
+			@Param("user") User user,
+			@Param("lastChatroomId") Long lastChatroomId,
+			@Param("cursorTime") Instant cursorTime,
+			PageRequest pageRequest
+	);
+
+	@Query("""
+			SELECT c
+			FROM ChatRoom c
+			JOIN FETCH c.chatMembers cm
+			WHERE cm.user = :user
+			AND c.status = 'ACTIVE'
+			ORDER BY c.lastActivityAt DESC, c.id DESC
+	""")
+	Slice<ChatRoom> findChatRooomsByMember(
+			@Param("user") User user,
+			PageRequest pageRequest
+	);
+
+	@Modifying
+	@Query("""
+			UPDATE ChatRoom c
+			SET c.status = 'DELETED'
+			WHERE c.id IN :chatRoomIds
+	""")
+	void updateOrphanedChatroom(@Param("chatRoomIds") List<Long> chatRoomIds);
+
+	Optional<ChatRoom> findChatroomByIdAndStatus(Long chatroomId, RoomStatus status);
+
+	@Query("""
+			SELECT c.id
+			FROM ChatRoom c
+			JOIN FETCH ChatMember cm ON cm.chatRoom = c
+			WHERE cm.status != 'JOINED'
+			AND c.createdAt < :threshold
+	""")
+	List<Long> findByOrphanedChatroomIds(@Param("threshold")Instant threshold);
+
+}

--- a/back/src/main/java/dev/kyudong/back/chat/scheduler/ChatRoomScheduler.java
+++ b/back/src/main/java/dev/kyudong/back/chat/scheduler/ChatRoomScheduler.java
@@ -1,0 +1,42 @@
+package dev.kyudong.back.chat.scheduler;
+
+import dev.kyudong.back.chat.repository.ChatRoomRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ChatRoomScheduler {
+
+	private final ChatRoomRepository chatRoomRepository;
+
+	@Scheduled(cron = "0 0 3 * * *")
+	@Transactional
+	public void cleanupOrphanedChatRoom() {
+		log.info("이용자가 없는 채팅방을 삭제처리합니다........");
+
+		// 일주일 기준 이용자가 없는 채팅룸 삭제
+		Instant threshold = Instant.now().minus(7, ChronoUnit.DAYS);
+		List<Long> orphanedChatRoomIds = chatRoomRepository.findByOrphanedChatroomIds(threshold);
+
+		if (orphanedChatRoomIds.isEmpty()) {
+			log.info("정리할 채팅방이 없습니다.........");
+			return;
+		}
+
+		int chatRoomSize = orphanedChatRoomIds.size();
+		log.info("{}개의 채팅방을 정리합니다!", chatRoomSize);
+
+		chatRoomRepository.updateOrphanedChatroom(orphanedChatRoomIds);
+		log.info("오래된 알림 {}개의 정리가 완료되었습니다", chatRoomSize);
+	}
+
+}

--- a/back/src/main/java/dev/kyudong/back/chat/service/ChatMemberService.java
+++ b/back/src/main/java/dev/kyudong/back/chat/service/ChatMemberService.java
@@ -1,0 +1,93 @@
+package dev.kyudong.back.chat.service;
+
+import dev.kyudong.back.chat.api.dto.event.ChatMemberInviteEvent;
+import dev.kyudong.back.chat.api.dto.event.ChatMemberLeftEvent;
+import dev.kyudong.back.chat.api.dto.req.ChatMemberInviteReqDto;
+import dev.kyudong.back.chat.domain.ChatMember;
+import dev.kyudong.back.chat.domain.ChatRoom;
+import dev.kyudong.back.chat.domain.MemberStatus;
+import dev.kyudong.back.chat.domain.RoomStatus;
+import dev.kyudong.back.chat.event.ChatEventHandler;
+import dev.kyudong.back.chat.exception.ChatMemberNotFoundException;
+import dev.kyudong.back.chat.exception.ChatRoomNotFoundException;
+import dev.kyudong.back.chat.repository.ChatMemberRepository;
+import dev.kyudong.back.chat.repository.ChatRoomRepository;
+import dev.kyudong.back.user.domain.User;
+import dev.kyudong.back.user.exception.UsersNotFoundException;
+import dev.kyudong.back.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ChatMemberService {
+
+	private final ChatMemberRepository chatMemberRepository;
+	private final ChatRoomRepository chatRoomRepository;
+	private final UserRepository userRepository;
+	private final ChatEventHandler chatEventHandler;
+
+	@Transactional
+	public void inviteChatRoom(final Long userId, final Long roomId, ChatMemberInviteReqDto requset) {
+		log.debug("채팅방에 새로운 사용자를 추가합니다: roomId={}", roomId);
+
+		ChatRoom chatRoom = chatRoomRepository.findChatroomByIdAndStatus(roomId, RoomStatus.ACTIVE)
+				.orElseThrow(() -> {
+					log.warn("존재하지 않는 채팅방입니다: roomId={}", roomId);
+					return new ChatRoomNotFoundException(roomId);
+				});
+
+		Set<Long> existsUserIds = chatMemberRepository.findExistsMemberUserIds(
+				requset.userIds(), chatRoom, MemberStatus.JOINED
+		);
+
+		if (!existsUserIds.contains(userId)) {
+			throw new ChatMemberNotFoundException(userId, roomId);
+		}
+
+		Set<Long> newUserIds = requset.userIds().stream()
+				.filter(id -> !existsUserIds.contains(id))
+				.collect(Collectors.toSet());
+
+		List<User> userList = userRepository.findByIdIn(newUserIds);
+		if (userList.isEmpty()) {
+			throw new UsersNotFoundException();
+		}
+
+		Set<ChatMember> newMembers = chatRoom.addNewMember(userList);
+
+		chatEventHandler.handleMemberInvite(ChatMemberInviteEvent.of(chatRoom, existsUserIds, newMembers));
+		log.info("새로운 사용자가 채팅방에 참여하였습니다: roomId={}", roomId);
+	}
+
+	@Transactional
+	public void leaveChatRoom(final Long roomId, final Long leaveUserId) {
+		log.debug("채팅방의 사용자가 채팅방을 탈퇴합니다: roomId={}, leaveUserId={}", roomId, leaveUserId);
+
+		ChatRoom chatRoom = chatRoomRepository.findChatroomByIdAndStatus(roomId, RoomStatus.ACTIVE)
+				.orElseThrow(() -> {
+					log.warn("존재하지 않는 채팅방입니다: roomId={}", roomId);
+					return new ChatRoomNotFoundException(roomId);
+				});
+
+		User leaveUser = userRepository.getReferenceById(leaveUserId);
+		ChatMember chatMember = chatMemberRepository.findByUserAndChatRoom(leaveUser, chatRoom)
+				.orElseThrow(() -> {
+					log.warn("채팅방에 존재하지 않는 사용자입니다: roomId={}, leaveUserId={}", roomId, leaveUserId);
+					return new ChatMemberNotFoundException(leaveUserId, roomId);
+				});
+
+		chatMember.leave();
+
+		chatEventHandler.handleMemberLeft(ChatMemberLeftEvent.of(roomId, leaveUserId, chatRoom.getChatMembers()));
+		log.info("사용자가 채팅방을 떠났습니다: roomId={}, leaveUserId={}", roomId, leaveUserId);
+	}
+
+}

--- a/back/src/main/java/dev/kyudong/back/chat/service/ChatMessageService.java
+++ b/back/src/main/java/dev/kyudong/back/chat/service/ChatMessageService.java
@@ -1,0 +1,116 @@
+package dev.kyudong.back.chat.service;
+
+import dev.kyudong.back.chat.api.dto.event.ChatMessageDeleteEvent;
+import dev.kyudong.back.chat.api.dto.event.ChatMessageCreateEvent;
+import dev.kyudong.back.chat.api.dto.req.ChatMessageCreateReqDto;
+import dev.kyudong.back.chat.api.dto.res.ChatMessageResDto;
+import dev.kyudong.back.chat.domain.ChatMember;
+import dev.kyudong.back.chat.domain.ChatMessage;
+import dev.kyudong.back.chat.domain.ChatRoom;
+import dev.kyudong.back.chat.event.ChatEventHandler;
+import dev.kyudong.back.chat.exception.ChatMessageNotFoundException;
+import dev.kyudong.back.chat.exception.ChatMemberNotFoundException;
+import dev.kyudong.back.chat.exception.ChatRoomNotFoundException;
+import dev.kyudong.back.chat.repository.ChatMessageRepository;
+import dev.kyudong.back.chat.repository.ChatMemberRepository;
+import dev.kyudong.back.chat.repository.ChatRoomRepository;
+import dev.kyudong.back.common.exception.InvalidAccessException;
+import dev.kyudong.back.user.domain.User;
+import dev.kyudong.back.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Instant;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ChatMessageService {
+
+	private final ChatMessageRepository chatMessageRepository;
+	private final ChatRoomRepository chatRoomRepository;
+	private final ChatMemberRepository chatMemberRepository;
+	private final UserRepository userRepository;
+	private final ChatEventHandler chatEventHandler;
+
+	@Transactional(readOnly = true)
+	public ChatMessageResDto findMessages(final Long roomId, Long cursorId, Instant cursorTime) {
+		log.debug("채팅 메시지를 조회합니다: roomId={}", roomId);
+
+		PageRequest pageRequest = PageRequest.of(0, 10);
+
+		Slice<ChatMessage> chatMessages = (cursorTime == null)
+				? chatMessageRepository.findChatMessage(roomId, pageRequest)
+				: chatMessageRepository.findChatMessageByCursorTime(roomId, cursorId, cursorTime, pageRequest);
+
+		return ChatMessageResDto.from(chatMessages);
+	}
+
+	@Transactional
+	public void createMessage(final Long userId, final Long roomId, ChatMessageCreateReqDto request) {
+		log.debug("사용자가 메시지를 전송합니다: userId={}, roomId={}", userId, roomId);
+
+		User user = userRepository.getReferenceById(userId);
+		ChatRoom chatRoom = chatRoomRepository.findById(roomId)
+				.orElseThrow(() -> {
+					log.warn("메시지를 전송한 채팅방이 존재하지 않습니다: roomId={}", roomId);
+					return new ChatRoomNotFoundException(roomId);
+				});
+
+		ChatMember sender = chatMemberRepository.findByUserAndChatRoom(user, chatRoom)
+				.orElseThrow(() -> {
+					log.warn("채팅방에 없는 사용자입니다: roomId={}, userId={}", roomId, userId);
+					return new ChatMemberNotFoundException(userId, roomId);
+				});
+
+		ChatMessage newChatMessage =  ChatMessage.builder()
+				.sender(sender)
+				.content(request.content())
+				.messageType(request.messageType())
+				.build();
+		chatRoom.addMessage(newChatMessage);
+		ChatMessage savedChatMessage = chatMessageRepository.save(newChatMessage);
+
+		chatEventHandler.handleMessageCreate(ChatMessageCreateEvent.of(savedChatMessage, chatRoom, sender.getUser()));
+		int size = chatRoom.getChatMembers().size();
+		log.info("메시지를 전송하였습니다: userId={}, roomId={}, size={}", userId, roomId, size);
+	}
+
+	@Transactional
+	public void deleteMessage(final Long userId, final Long roomId, final Long messageId) {
+		log.debug("사용자의 메시지를 삭제합니다: userId={}, roomId={}", userId, roomId);
+
+		User user = userRepository.getReferenceById(userId);
+		ChatRoom chatRoom = chatRoomRepository.findById(roomId)
+				.orElseThrow(() -> {
+					log.warn("메시지를 삭제할 채팅방이 존재하지 않습니다: roomId={}", roomId);
+					return new ChatRoomNotFoundException(roomId);
+				});
+
+		ChatMember sender = chatMemberRepository.findByUserAndChatRoom(user, chatRoom)
+				.orElseThrow(() -> {
+					log.warn("채팅방에 없는 사용자입니다: roomId={}, userId={}", roomId, userId);
+					return new ChatMemberNotFoundException(userId, roomId);
+				});
+
+		ChatMessage chatMessage = chatMessageRepository.findByIdAndChatRoomAndSender(messageId, chatRoom, sender)
+				.orElseThrow(() -> {
+					log.warn("존재하지 않는 메시지입니다: messageId={}, roomId={}", messageId, roomId);
+					return new ChatMessageNotFoundException(messageId, roomId);
+				});
+
+		if (!chatMessage.getSender().getUser().getId().equals(userId)) {
+			throw new InvalidAccessException("메시지를 삭제할 권한이 없습니다");
+		}
+
+		chatMessage.delete();
+
+		chatEventHandler.handleMessageDelete(ChatMessageDeleteEvent.of(chatMessage, chatRoom, userId));
+		log.info("메시지를 삭제하였습니다: userId={}, roomId={}", userId, roomId);
+	}
+
+}

--- a/back/src/main/java/dev/kyudong/back/chat/service/ChatRoomService.java
+++ b/back/src/main/java/dev/kyudong/back/chat/service/ChatRoomService.java
@@ -1,0 +1,67 @@
+package dev.kyudong.back.chat.service;
+
+import dev.kyudong.back.chat.api.dto.event.ChatRoomCreateEvent;
+import dev.kyudong.back.chat.api.dto.req.ChatRoomCreateReqDto;
+import dev.kyudong.back.chat.api.dto.res.ChatRoomCreateResDto;
+import dev.kyudong.back.chat.api.dto.res.ChatRoomResDto;
+import dev.kyudong.back.chat.domain.ChatRoom;
+import dev.kyudong.back.chat.event.ChatEventHandler;
+import dev.kyudong.back.chat.repository.ChatRoomRepository;
+import dev.kyudong.back.user.domain.User;
+import dev.kyudong.back.user.exception.UsersNotFoundException;
+import dev.kyudong.back.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Instant;
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ChatRoomService {
+
+	private final ChatRoomRepository chatRoomRepository;
+	private final UserRepository userRepository;
+	private final ChatEventHandler chatEventHandler;
+
+	@Transactional(readOnly = true)
+	public ChatRoomResDto findChatRooms(final Long userId, Long lastChatroomId, Instant cursorTime) {
+		log.debug("채팅방 목록을 조회합니다: userId={}", userId);
+
+		User user = userRepository.getReferenceById(userId);
+		PageRequest pageRequest = PageRequest.of(0, 10);
+
+		Slice<ChatRoom> chatRooms = (lastChatroomId == null)
+				? chatRoomRepository.findChatRooomsByMember(user, pageRequest)
+				: chatRoomRepository.findChatRooomsByMember(user, lastChatroomId, cursorTime, pageRequest);
+
+		return ChatRoomResDto.from(chatRooms);
+	}
+
+	@Transactional
+	public ChatRoomCreateResDto createChatRoom(final Long userId, ChatRoomCreateReqDto request) {
+		log.debug("채팅방 생성합니다: userId={}", userId);
+
+		List<User> userList = userRepository.findByIdIn(request.userIds());
+		if (userList.isEmpty()) {
+			throw new UsersNotFoundException();
+		}
+
+		ChatRoom newChatRoom = ChatRoom.builder()
+				.initUserList(userList)
+				.build();
+
+		ChatRoom savedChatRoom = chatRoomRepository.save(newChatRoom);
+		log.info("채팅방 생성이 완료되었습니다: userId={}", userId);
+
+		chatEventHandler.handleRoomCreate(ChatRoomCreateEvent.from(savedChatRoom));
+
+		return ChatRoomCreateResDto.from(savedChatRoom);
+	}
+
+}

--- a/back/src/main/java/dev/kyudong/back/chat/websocket/ChatBroadCaster.java
+++ b/back/src/main/java/dev/kyudong/back/chat/websocket/ChatBroadCaster.java
@@ -1,0 +1,56 @@
+package dev.kyudong.back.chat.websocket;
+
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+import java.util.Set;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ChatBroadCaster {
+
+	private final ChatWebSocketHandler chatWebSocketHandler;
+
+	/**
+	 * 지정된 사용자 ID 목록(채팅방 참여자)에게 동일한 메시지를 비동기적으로 브로드캐스팅합니다.
+	 * <p>
+	 * 이 메소드는 {@link org.springframework.scheduling.annotation.Async @Async}로 동작하므로,
+	 * 호출 즉시 반환되며 실제 메시지 전송은 별도의 스레드 풀에서 수행됩니다.
+	 *
+	 * @param users                메시지를 수신할 사용자 ID의 Set
+	 * @param webSocketMessage     전송할 메시지 ({@link ChatWebSocketMessage}).
+	 * @see ChatWebSocketHandler#sendChatMessage(Long, ChatWebSocketMessage)
+	 */
+	@Async
+	public <T> void brodCastMessageToMembers(@NonNull Set<Long> users, @NonNull ChatWebSocketMessage<T> webSocketMessage) {
+		log.debug("{}명에게 메시지를 전송합니다", users.size());
+
+		users.forEach(userId -> chatWebSocketHandler.sendChatMessage(userId, webSocketMessage));
+
+		log.debug("메시지 전송이 완료되었습니다");
+	}
+
+	/**
+	 * 메시지 목록을 서로다른 내용의 메시지를 비동기적으로 브로드캐스팅합니다.
+	 * <p>
+	 * 이 메소드는 {@link org.springframework.scheduling.annotation.Async @Async}로 동작하므로,
+	 * 호출 즉시 반환되며 실제 메시지 전송은 별도의 스레드 풀에서 수행됩니다.
+	 *
+	 * @param webSocketMessage     전송할 메시지 ({@link ChatWebSocketMessage}).
+	 * @see ChatWebSocketHandler#sendChatMessage(Long, ChatWebSocketMessage)
+	 */
+	@Async
+	public <T> void brodCastIndividualMessages(@NonNull Map<Long, ChatWebSocketMessage<T>> webSocketMessage) {
+		log.debug("{}명에게 개별 메시지를 전송합니다", webSocketMessage.size());
+
+		webSocketMessage.forEach(chatWebSocketHandler::sendChatMessage);
+
+		log.debug("개별 메시지 전송이 완료되었습니다");
+	}
+
+}

--- a/back/src/main/java/dev/kyudong/back/chat/websocket/ChatWebSocketHandler.java
+++ b/back/src/main/java/dev/kyudong/back/chat/websocket/ChatWebSocketHandler.java
@@ -1,0 +1,39 @@
+package dev.kyudong.back.chat.websocket;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import dev.kyudong.back.common.websocket.BaseWebSocketHandler;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.TextMessage;
+import org.springframework.web.socket.WebSocketSession;
+
+import java.io.IOException;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public final class ChatWebSocketHandler extends BaseWebSocketHandler {
+
+	private final ObjectMapper objectMapper;
+
+	public <T> void sendChatMessage(final Long userId, ChatWebSocketMessage<T> payload) {
+		log.debug("메시지를 전송합니다: userId={}", userId);
+		WebSocketSession session = super.getSession(userId);
+		if (session != null && session.isOpen()) {
+			try {
+				String message=  objectMapper.writeValueAsString(payload);
+				session.sendMessage(new TextMessage(message));
+				log.debug("메시지를 전송했습니다: userId={}. content={}", userId, payload);
+			} catch (JsonProcessingException j) {
+				log.error("메시지 파싱에 실패했습니다: payload={}", payload, j);
+			} catch (IOException i) {
+				log.error("입출력 에러가 발생했습니다", i);
+			} catch (Exception e) {
+				log.error("에러가 발생했습니다", e);
+			}
+		}
+	}
+
+}

--- a/back/src/main/java/dev/kyudong/back/chat/websocket/ChatWebSocketMessage.java
+++ b/back/src/main/java/dev/kyudong/back/chat/websocket/ChatWebSocketMessage.java
@@ -1,0 +1,12 @@
+package dev.kyudong.back.chat.websocket;
+
+import dev.kyudong.back.chat.event.ChatEventType;
+
+public record ChatWebSocketMessage<T>(
+		ChatEventType type,
+		T payload
+) {
+	public static <T> ChatWebSocketMessage<T> of(ChatEventType type, T payload) {
+		return new ChatWebSocketMessage<>(type, payload);
+	}
+}

--- a/back/src/main/java/dev/kyudong/back/common/config/AsyncConfig.java
+++ b/back/src/main/java/dev/kyudong/back/common/config/AsyncConfig.java
@@ -1,0 +1,29 @@
+package dev.kyudong.back.common.config;
+
+import lombok.NonNull;
+import org.springframework.scheduling.annotation.AsyncConfigurer;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.Executor;
+
+@Component
+@EnableAsync
+public class AsyncConfig implements AsyncConfigurer {
+
+	@Override
+	public @NonNull Executor getAsyncExecutor() {
+		ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+
+		executor.setCorePoolSize(5);
+		executor.setMaxPoolSize(10);
+		executor.setQueueCapacity(20);
+		executor.setThreadNamePrefix("signal-async-task-");
+
+		executor.initialize();
+
+		return executor;
+	}
+
+}

--- a/back/src/main/java/dev/kyudong/back/common/config/SecurityConfig.java
+++ b/back/src/main/java/dev/kyudong/back/common/config/SecurityConfig.java
@@ -34,7 +34,8 @@ public class SecurityConfig {
 				.formLogin(AbstractHttpConfigurer::disable)
 				.sessionManagement(seession -> seession.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
 				.authorizeHttpRequests(auth ->
-					auth.requestMatchers(HttpMethod.GET, "/api/v1/posts/**").permitAll()
+					auth.requestMatchers("/ws/**").permitAll() // Interceptor가 처리
+						.requestMatchers(HttpMethod.GET, "/api/v1/posts/**").permitAll()
 						.requestMatchers(HttpMethod.GET, "/swagger-ui/**", "/v3/api-docs/**").permitAll()
 						.requestMatchers(HttpMethod.POST, "/api/v1/users", "/api/v1/users/login").permitAll()
 						.anyRequest().authenticated()

--- a/back/src/main/java/dev/kyudong/back/common/config/WebSocketConfig.java
+++ b/back/src/main/java/dev/kyudong/back/common/config/WebSocketConfig.java
@@ -1,8 +1,10 @@
 package dev.kyudong.back.common.config;
 
+import dev.kyudong.back.chat.websocket.ChatWebSocketHandler;
+import dev.kyudong.back.common.jwt.JwtHandshakeInterceptor;
+import dev.kyudong.back.notification.handler.NotificationWebSocketHandler;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.web.socket.WebSocketHandler;
 import org.springframework.web.socket.config.annotation.EnableWebSocket;
 import org.springframework.web.socket.config.annotation.WebSocketConfigurer;
 import org.springframework.web.socket.config.annotation.WebSocketHandlerRegistry;
@@ -12,12 +14,16 @@ import org.springframework.web.socket.config.annotation.WebSocketHandlerRegistry
 @RequiredArgsConstructor
 public class WebSocketConfig implements WebSocketConfigurer {
 
-	private final WebSocketHandler webSocketHandler;
+	private final NotificationWebSocketHandler notificationWebSocketHandler;
+	private final ChatWebSocketHandler chatWebSocketHandler;
+	private final JwtHandshakeInterceptor jwtHandshakeInterceptor;
 
 	@Override
 	public void registerWebSocketHandlers(WebSocketHandlerRegistry registry) {
-		registry.addHandler(webSocketHandler, "/ws/notifications")
-				.setAllowedOrigins("*"); // todo : 현재는 개발단계로 모든 도메인을 허용함, 추후 설정 필요
+		registry.addHandler(notificationWebSocketHandler, "/ws/notifications")
+				.addHandler(chatWebSocketHandler, "/ws/chat")
+				.addInterceptors(jwtHandshakeInterceptor)
+				.setAllowedOrigins("*");
 	}
 
 }

--- a/back/src/main/java/dev/kyudong/back/common/exception/GlobalExceptionHandler.java
+++ b/back/src/main/java/dev/kyudong/back/common/exception/GlobalExceptionHandler.java
@@ -1,5 +1,9 @@
 package dev.kyudong.back.common.exception;
 
+import dev.kyudong.back.chat.exception.ChatMessageNotFoundException;
+import dev.kyudong.back.chat.exception.ChatMemberExistsException;
+import dev.kyudong.back.chat.exception.ChatMemberNotFoundException;
+import dev.kyudong.back.chat.exception.ChatRoomNotFoundException;
 import dev.kyudong.back.file.exception.FileMetadataNotFoundException;
 import dev.kyudong.back.file.exception.InvalidFileException;
 import dev.kyudong.back.follow.exception.AlreadyFollowException;
@@ -11,6 +15,7 @@ import dev.kyudong.back.post.exception.CommentNotFoundException;
 import dev.kyudong.back.post.exception.PostNotFoundException;
 import dev.kyudong.back.user.exception.UserAlreadyExistsException;
 import dev.kyudong.back.user.exception.UserNotFoundException;
+import dev.kyudong.back.user.exception.UsersNotFoundException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ProblemDetail;
 import org.springframework.http.ResponseEntity;
@@ -150,6 +155,56 @@ public class GlobalExceptionHandler {
 		problemDetail.setDetail(e.getMessage());
 		problemDetail.setProperty("timestamp", Instant.now());
 		return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(problemDetail);
+	}
+
+	@ExceptionHandler(UsersNotFoundException.class)
+	protected ResponseEntity<ProblemDetail> handleUsersNotFoundException(UsersNotFoundException e) {
+		ProblemDetail problemDetail = ProblemDetail.forStatusAndDetail(HttpStatus.NOT_FOUND, e.getMessage());
+		problemDetail.setTitle("Users Not Found");
+		problemDetail.setStatus(HttpStatus.NOT_FOUND);
+		problemDetail.setDetail(e.getMessage());
+		problemDetail.setProperty("timestamp", Instant.now());
+		return ResponseEntity.status(HttpStatus.NOT_FOUND).body(problemDetail);
+	}
+
+	@ExceptionHandler(ChatMessageNotFoundException.class)
+	protected ResponseEntity<ProblemDetail> handleChatMessageNotFoundException(ChatMessageNotFoundException e) {
+		ProblemDetail problemDetail = ProblemDetail.forStatusAndDetail(HttpStatus.NOT_FOUND, e.getMessage());
+		problemDetail.setTitle("Chat Message Not Found");
+		problemDetail.setStatus(HttpStatus.NOT_FOUND);
+		problemDetail.setDetail(e.getMessage());
+		problemDetail.setProperty("timestamp", Instant.now());
+		return ResponseEntity.status(HttpStatus.NOT_FOUND).body(problemDetail);
+	}
+
+	@ExceptionHandler(ChatMemberExistsException.class)
+	protected ResponseEntity<ProblemDetail> handleChatMemberExistsException(ChatMemberExistsException e) {
+		ProblemDetail problemDetail = ProblemDetail.forStatusAndDetail(HttpStatus.NOT_FOUND, e.getMessage());
+		problemDetail.setTitle("Chat Member Not Exists");
+		problemDetail.setStatus(HttpStatus.NOT_FOUND);
+		problemDetail.setDetail(e.getMessage());
+		problemDetail.setProperty("timestamp", Instant.now());
+		return ResponseEntity.status(HttpStatus.NOT_FOUND).body(problemDetail);
+	}
+
+	@ExceptionHandler(ChatRoomNotFoundException.class)
+	protected ResponseEntity<ProblemDetail> handleChatRoomNotFoundException(ChatRoomNotFoundException e) {
+		ProblemDetail problemDetail = ProblemDetail.forStatusAndDetail(HttpStatus.NOT_FOUND, e.getMessage());
+		problemDetail.setTitle("Chat Room Not Found");
+		problemDetail.setStatus(HttpStatus.NOT_FOUND);
+		problemDetail.setDetail(e.getMessage());
+		problemDetail.setProperty("timestamp", Instant.now());
+		return ResponseEntity.status(HttpStatus.NOT_FOUND).body(problemDetail);
+	}
+
+	@ExceptionHandler(ChatMemberNotFoundException.class)
+	protected ResponseEntity<ProblemDetail> handleChatMemberNotFoundException(ChatMemberNotFoundException e) {
+		ProblemDetail problemDetail = ProblemDetail.forStatusAndDetail(HttpStatus.NOT_FOUND, e.getMessage());
+		problemDetail.setTitle("Chat Member Not Found");
+		problemDetail.setStatus(HttpStatus.NOT_FOUND);
+		problemDetail.setDetail(e.getMessage());
+		problemDetail.setProperty("timestamp", Instant.now());
+		return ResponseEntity.status(HttpStatus.NOT_FOUND).body(problemDetail);
 	}
 
 }

--- a/back/src/main/java/dev/kyudong/back/common/jwt/JwtHandshakeInterceptor.java
+++ b/back/src/main/java/dev/kyudong/back/common/jwt/JwtHandshakeInterceptor.java
@@ -1,0 +1,71 @@
+package dev.kyudong.back.common.jwt;
+
+import jakarta.annotation.Nullable;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.server.ServerHttpRequest;
+import org.springframework.http.server.ServerHttpResponse;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.WebSocketHandler;
+import org.springframework.web.socket.server.HandshakeInterceptor;
+
+import java.util.Map;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JwtHandshakeInterceptor implements HandshakeInterceptor {
+
+	private final JwtUtil jwtUtil;
+	private final UserDetailsService userDetailsService;
+
+	@Override
+	public boolean beforeHandshake(
+			@NonNull ServerHttpRequest request,
+			@NonNull ServerHttpResponse response,
+			@NonNull WebSocketHandler wsHandler,
+			@NonNull Map<String, Object> attributes
+	) {
+		log.debug("핸드세이크 시작");
+		String token = resolveToken(request);
+
+		if (token != null && jwtUtil.validateToken(token)) {
+			String username = jwtUtil.getUsernameFromToken(token);
+			UserDetails userDetails = userDetailsService.loadUserByUsername(username);
+			UsernamePasswordAuthenticationToken authenticationToken =
+					new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+
+			SecurityContextHolder.getContext().setAuthentication(authenticationToken);
+			attributes.put("principal", authenticationToken);
+
+			log.info("WebSocket 핸드 셰이크가 성공했습니다: User {}", authenticationToken.getName());
+			return true;
+		}
+
+		log.warn("WebSocket 핸드 셰이크가 실패했습니다: 토큰이 유효하지 않음");
+		return false;
+	}
+
+	@Override
+	public void afterHandshake(
+			@NonNull ServerHttpRequest request,
+			@NonNull ServerHttpResponse response,
+			@NonNull WebSocketHandler wsHandler,
+			@Nullable Exception exception) {
+		log.debug("WebSocket 핸드세이크 종료");
+	}
+
+	private String resolveToken(ServerHttpRequest request) {
+		String token = request.getURI().getQuery();
+		if (token != null && token.startsWith("token=")) {
+			return token.substring(6);
+		}
+		return null;
+	}
+
+}

--- a/back/src/main/java/dev/kyudong/back/common/websocket/BaseWebSocketHandler.java
+++ b/back/src/main/java/dev/kyudong/back/common/websocket/BaseWebSocketHandler.java
@@ -1,0 +1,52 @@
+package dev.kyudong.back.common.websocket;
+
+import dev.kyudong.back.user.security.CustomUserPrincipal;
+import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.socket.CloseStatus;
+import org.springframework.web.socket.WebSocketSession;
+import org.springframework.web.socket.handler.TextWebSocketHandler;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Slf4j
+public class BaseWebSocketHandler extends TextWebSocketHandler {
+
+	private final Map<Long, WebSocketSession> sessions = new ConcurrentHashMap<>();
+
+	protected WebSocketSession getSession(Long userId) {
+		return sessions.get(userId);
+	}
+
+	@Override
+	public void afterConnectionEstablished(@NonNull WebSocketSession session) throws Exception {
+		Long userId = getUserId(session);
+		if (userId == null) {
+			log.warn("웹 소켓 연결에 실패했습니다: 사용자 인증 실패");
+			session.close(CloseStatus.POLICY_VIOLATION.withReason("사용자 인증 실패"));
+			return;
+		}
+		sessions.put(userId, session);
+	}
+
+	@Override
+	public void afterConnectionClosed(@NonNull WebSocketSession session, @NonNull CloseStatus status) {
+		Long userId  = getUserId(session);
+		if (userId != null) {
+			sessions.remove(userId);
+			log.info("웹 소켓 연결이 종료되었습니다: userId={} status={}", userId, status);
+		}
+	}
+
+	private Long getUserId(WebSocketSession session) {
+		if (session.getPrincipal() instanceof Authentication authentication) {
+			if (authentication.getPrincipal() instanceof CustomUserPrincipal) {
+				return ((CustomUserPrincipal) authentication.getPrincipal()).getId();
+			}
+		}
+		return null;
+	}
+
+}

--- a/back/src/main/java/dev/kyudong/back/notification/event/DefaultNotificationEventHandler.java
+++ b/back/src/main/java/dev/kyudong/back/notification/event/DefaultNotificationEventHandler.java
@@ -65,7 +65,7 @@ public class DefaultNotificationEventHandler implements NotificationEventHandler
 
 		savedNotifications.forEach(notification -> {
 			NotificationDetailResDto notificationDetailResDto = NotificationDetailResDto.from(notification);
-			notificationWebSocketHandler.sendMessageToUser(notificationDetailResDto.receiverId(), notificationDetailResDto);
+			notificationWebSocketHandler.sendNotificationToUser(notificationDetailResDto.receiverId(), notificationDetailResDto);
 		});
 	}
 

--- a/back/src/main/java/dev/kyudong/back/notification/handler/NotificationWebSocketHandler.java
+++ b/back/src/main/java/dev/kyudong/back/notification/handler/NotificationWebSocketHandler.java
@@ -1,70 +1,35 @@
 package dev.kyudong.back.notification.handler;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import dev.kyudong.back.common.websocket.BaseWebSocketHandler;
 import dev.kyudong.back.notification.api.dto.res.NotificationDetailResDto;
-import dev.kyudong.back.user.security.CustomUserPrincipal;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Component;
-import org.springframework.web.socket.CloseStatus;
 import org.springframework.web.socket.TextMessage;
 import org.springframework.web.socket.WebSocketSession;
-import org.springframework.web.socket.handler.TextWebSocketHandler;
 
 import java.io.IOException;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 
 @Slf4j
 @Component
 @RequiredArgsConstructor
-public class NotificationWebSocketHandler extends TextWebSocketHandler {
+public class NotificationWebSocketHandler extends BaseWebSocketHandler {
 
-	private final Map<Long, WebSocketSession> sessions = new ConcurrentHashMap<>();
 	private final ObjectMapper objectMapper;
 
-	@Override
-	public void afterConnectionEstablished(WebSocketSession session) throws Exception {
-		Long userId = getUserId(session);
-		if (userId == null) {
-			log.warn("웹 소켓 연결에 실패했습니다: 사용자 인증 실패");
-			session.close(CloseStatus.POLICY_VIOLATION.withReason("사용자 인증 실패"));
-			return;
-		}
-		sessions.put(userId, session);
-	}
-
-	@Override
-	public void afterConnectionClosed(WebSocketSession session, CloseStatus status) throws Exception {
-		Long userId  = getUserId(session);
-		if (userId != null) {
-			sessions.remove(userId);
-			log.info("웹 소켓 연결이 종료되었습니다: userId={} status={}", userId, status);
-		}
-	}
-
-	public void sendMessageToUser(final Long userId, NotificationDetailResDto notificationDetailResDto) {
-		log.debug("메시지를 전송을 시작합니다: userId={}", userId);
-		WebSocketSession session = sessions.get(userId);
+	public void sendNotificationToUser(final Long userId, NotificationDetailResDto notificationDetailResDto) {
+		log.debug("사용자에게 알림을 전송합니다: userId={}", userId);
+		WebSocketSession session = super.getSession(userId);
 		if (session != null && session.isOpen()) {
 			try {
 				String message = objectMapper.writeValueAsString(notificationDetailResDto);
 				session.sendMessage(new TextMessage(message));
-				log.info("메시지 전송를 전송했습니다: userId={}. message={}", userId, message);
+				log.info("사용자에게 알림을 전송했습니다: userId={}. message={}", userId, message);
 			} catch (IOException e) {
-				log.error("메시지 전달에 실패했습니다: userId={}", userId);
+				log.error("사용자에게 알림을 실패했습니다: userId={}", userId);
 			}
 		}
-	}
-
-	private Long getUserId(WebSocketSession session) {
-		if (session.getPrincipal() instanceof Authentication authentication) {
-			if (authentication.getPrincipal() instanceof CustomUserPrincipal) {
-				return ((CustomUserPrincipal) authentication.getPrincipal()).getId();
-			}
-		}
-		return null;
 	}
 
 }

--- a/back/src/main/java/dev/kyudong/back/post/domain/Comment.java
+++ b/back/src/main/java/dev/kyudong/back/post/domain/Comment.java
@@ -33,7 +33,7 @@ public class Comment {
 	private User user;
 
 	@Lob
-	@Column(name = "CONTENT", nullable = false)
+	@Column(name = "CONTENT", nullable = false, columnDefinition = "TEXT")
 	private String content;
 
 	@CreatedDate

--- a/back/src/main/java/dev/kyudong/back/post/domain/Post.java
+++ b/back/src/main/java/dev/kyudong/back/post/domain/Post.java
@@ -34,7 +34,7 @@ public class Post {
 	private String subject;
 
 	@Lob
-	@Column(name = "CONTENT", nullable = false)
+	@Column(name = "CONTENT", nullable = false, columnDefinition = "TEXT")
 	private String content;
 
 	@CreatedDate

--- a/back/src/main/java/dev/kyudong/back/user/domain/User.java
+++ b/back/src/main/java/dev/kyudong/back/user/domain/User.java
@@ -107,4 +107,20 @@ public class User {
 		post.associateUser(this);
 	}
 
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) return true;
+		if (o == null || getClass() != o.getClass()) return false;
+
+		User user = (User) o;
+
+		if (!Objects.equals(id, user.id)) return false;
+		return Objects.equals(username, user.username);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(username);
+	}
+
 }

--- a/back/src/main/java/dev/kyudong/back/user/exception/UsersNotFoundException.java
+++ b/back/src/main/java/dev/kyudong/back/user/exception/UsersNotFoundException.java
@@ -1,0 +1,7 @@
+package dev.kyudong.back.user.exception;
+
+public class UsersNotFoundException extends RuntimeException {
+	public UsersNotFoundException() {
+		super("요청한 사용자 목록을 조회할 수 없습니다");
+	}
+}

--- a/back/src/main/java/dev/kyudong/back/user/repository/UserRepository.java
+++ b/back/src/main/java/dev/kyudong/back/user/repository/UserRepository.java
@@ -3,12 +3,16 @@ package dev.kyudong.back.user.repository;
 import dev.kyudong.back.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 public interface UserRepository extends JpaRepository<User, Long> {
 
 	boolean existsByUsername(String username);
 
 	Optional<User> findByUsername(String username);
+
+	List<User> findByIdIn(Set<Long> userIds);
 
 }

--- a/back/src/main/resources/application-dev.yml
+++ b/back/src/main/resources/application-dev.yml
@@ -28,6 +28,10 @@ spring:
         format_sql: true
         default_batch_fetch_size: 100 # N+1 문제 해결을 위한 배치 사이즈 설정 (성능 튜닝)
     open-in-view: false
+  task:
+    scheduling:
+      pool:
+        size: 5
 
 # ===================================================================
 # Springdoc (Swagger UI) Configuration
@@ -51,8 +55,8 @@ logging:
   level:
     root: INFO
     org.springframework: INFO
-    org.hibernate: INFO
-    org.apache.tomcat: INFO
+    org.hibernate: WARN
+    org.apache.tomcat: WARN
     dev.kyudong.back: DEBUG
 
 # ===================================================================

--- a/back/src/main/resources/application-test.yml
+++ b/back/src/main/resources/application-test.yml
@@ -1,0 +1,40 @@
+# ===================================================================
+# Spring Boot Core Configuration
+# ===================================================================
+spring:
+  datasource:
+    url: jdbc:h2:mem:testdb-${random.uuid};MODE=PostgreSQL;DB_CLOSE_DELAY=-1
+    driver-class-name: org.h2.Driver
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.PostgreSQLDialect
+        show_sql: true
+        format_sql: true
+    open-in-view: false
+
+# ===================================================================
+# log Configuration
+# ===================================================================
+logging:
+  level:
+    root: INFO
+    org.springframework: INFO
+    org.hibernate: WARN
+    dev.kyudong.back: DEBUG
+
+# ===================================================================
+# jwt Configuration
+# ===================================================================
+jwt:
+  secret: SGVsbG9AI2UzV3JvbGQhQCN9RHxkc2prZC0oOTBNeVNlY3JldCEyMyRGREcjMw==
+  expiration-time: 3600000
+
+# ===================================================================
+# file Configuration
+# ===================================================================
+file:
+  upload-dir: /test/uploads
+  public-web-path: /media/

--- a/back/src/test/java/dev/kyudong/back/chat/member/ChatMemberControllerTests.java
+++ b/back/src/test/java/dev/kyudong/back/chat/member/ChatMemberControllerTests.java
@@ -1,0 +1,123 @@
+package dev.kyudong.back.chat.member;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import dev.kyudong.back.chat.api.ChatMemberController;
+import dev.kyudong.back.chat.api.dto.req.ChatMemberInviteReqDto;
+import dev.kyudong.back.chat.exception.ChatMemberNotFoundException;
+import dev.kyudong.back.chat.exception.ChatRoomNotFoundException;
+import dev.kyudong.back.chat.service.ChatMemberService;
+import dev.kyudong.back.common.config.SecurityConfig;
+import dev.kyudong.back.common.jwt.JwtUtil;
+import dev.kyudong.back.security.WithMockCustomUser;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.MediaType;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.Set;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.*;
+import static org.mockito.Mockito.doNothing;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(ChatMemberController.class)
+@Import(SecurityConfig.class)
+public class ChatMemberControllerTests {
+
+	@Autowired
+	private ObjectMapper objectMapper;
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@SuppressWarnings("unused")
+	@MockitoBean
+	private ChatMemberService chatMemberService;
+
+	@SuppressWarnings("unused")
+	@MockitoBean
+	private JwtUtil jwtUtil;
+
+	@SuppressWarnings("unused")
+	@MockitoBean
+	private UserDetailsService userDetailsService;
+
+	@Test
+	@DisplayName("채팅방 초대 - 성공")
+	@WithMockCustomUser(id = 999L)
+	void inviteChatroomApi_success() throws Exception {
+		// given
+		final Long userId = 999L;
+		final Long roomId = 1L;
+		ChatMemberInviteReqDto requset = new ChatMemberInviteReqDto(Set.of(1L));
+		doNothing().when(chatMemberService).inviteChatRoom(userId, roomId, requset);
+
+		// when & then
+		mockMvc.perform(post("/api/v1/chatroom/{roomId}/members", roomId)
+						.contentType(MediaType.APPLICATION_JSON.toString())
+						.content(objectMapper.writeValueAsString(requset)))
+				.andExpect(status().isNoContent())
+				.andDo(print());
+	}
+
+	@Test
+	@DisplayName("채팅방 초대 - 실패 : 존재하지 않는 채팅방")
+	@WithMockCustomUser(id = 999L)
+	void inviteChatroomApi_fail_roomNotFound() throws Exception {
+		// given
+		final Long roomId = 1L;
+		ChatMemberInviteReqDto requset = new ChatMemberInviteReqDto(Set.of(1L));
+		willThrow(new ChatRoomNotFoundException(roomId))
+				.given(chatMemberService)
+				.inviteChatRoom(anyLong(), anyLong(), any(ChatMemberInviteReqDto.class));
+
+		// when & then
+		mockMvc.perform(post("/api/v1/chatroom/{roomId}/members", roomId)
+						.contentType(MediaType.APPLICATION_JSON.toString())
+						.content(objectMapper.writeValueAsString(requset)))
+				.andExpect(status().isNotFound())
+				.andDo(print());
+	}
+
+	@Test
+	@DisplayName("채팅방 탈퇴 - 성공")
+	@WithMockCustomUser(id = 999L)
+	void leaveChatroomApi_success() throws Exception {
+		// given
+		final Long userId = 999L;
+		final Long roomId = 1L;
+		doNothing().when(chatMemberService).leaveChatRoom(userId, roomId);
+
+		// when & then
+		mockMvc.perform(delete("/api/v1/chatroom/{roomId}/members/me", roomId))
+				.andExpect(status().isNoContent())
+				.andDo(print());
+	}
+
+	@Test
+	@DisplayName("채팅방 탈퇴 - 실패 : 채팅방에 없는 사용자")
+	@WithMockCustomUser(id = 999L)
+	void leaveChatroomApi_fail_memberNotFound() throws Exception {
+		// given
+		final Long leaveUserId = 999L;
+		final Long roomId = 1L;
+		willThrow(new ChatMemberNotFoundException(leaveUserId, roomId))
+				.given(chatMemberService)
+				.leaveChatRoom(anyLong(), anyLong());
+
+		// when & then
+		mockMvc.perform(delete("/api/v1/chatroom/{roomId}/members/me", roomId))
+				.andExpect(status().isNotFound())
+				.andDo(print());
+	}
+
+}

--- a/back/src/test/java/dev/kyudong/back/chat/member/ChatMemberIntegrationTests.java
+++ b/back/src/test/java/dev/kyudong/back/chat/member/ChatMemberIntegrationTests.java
@@ -1,0 +1,131 @@
+package dev.kyudong.back.chat.member;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import dev.kyudong.back.chat.api.dto.req.ChatMemberInviteReqDto;
+import dev.kyudong.back.chat.domain.*;
+import dev.kyudong.back.chat.event.ChatEventHandler;
+import dev.kyudong.back.chat.repository.ChatMemberRepository;
+import dev.kyudong.back.chat.repository.ChatRoomRepository;
+import dev.kyudong.back.common.jwt.JwtUtil;
+import dev.kyudong.back.user.domain.User;
+import dev.kyudong.back.user.repository.UserRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.MediaType;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpHeaders;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@Transactional
+@SpringBootTest
+@AutoConfigureMockMvc
+public class ChatMemberIntegrationTests {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Autowired
+	private ObjectMapper objectMapper;
+
+	@Autowired
+	private UserRepository userRepository;
+
+	@Autowired
+	private ChatRoomRepository chatRoomRepository;
+
+	@Autowired
+	private ChatMemberRepository chatMemberRepository;
+
+	/**
+	 * 웹소켓 이벤트는 해당 테스트 클래스에서 다루지 않습니다
+	 */
+	@SuppressWarnings("unused")
+	@MockitoSpyBean
+	private ChatEventHandler chatEventHandler;
+
+	@Autowired
+	private JwtUtil jwtUtil;
+
+	private User createTestUser(String username) {
+		User newUser = User.builder()
+				.username(username)
+				.rawPassword("password")
+				.encodedPassword("password")
+				.build();
+		return userRepository.save(newUser);
+	}
+
+	private ChatRoom createTestChatRoom(List<User> userList) {
+		ChatRoom newChatRoom = ChatRoom.builder()
+				.initUserList(userList)
+				.build();
+		return chatRoomRepository.save(newChatRoom);
+	}
+
+	@Test
+	@DisplayName("채팅방 초대")
+	void inviteChatRoom() throws Exception {
+		// given
+		User user = createTestUser("dkdlsa");
+		ChatRoom chatRoom = createTestChatRoom(List.of(user));
+
+		// 초대할 사용자
+		User inviteUser = createTestUser("ckvczxvcxz");
+
+		ChatMemberInviteReqDto request = new ChatMemberInviteReqDto(Set.of(user.getId(), inviteUser.getId()));
+
+		// when
+		mockMvc.perform(post("/api/v1/chatroom/{roomId}/members", chatRoom.getId())
+							.header(HttpHeaders.AUTHORIZATION, "Bearer " + jwtUtil.generateToken(user))
+							.contentType(MediaType.APPLICATION_JSON.toString())
+							.content(objectMapper.writeValueAsString(request)))
+					.andExpect(status().isNoContent())
+					.andDo(print())
+					.andReturn();
+
+		// then
+		Optional<ChatMember> optionalChatMember = chatMemberRepository.findByUserAndChatRoom(inviteUser, chatRoom);
+		assertThat(optionalChatMember).isPresent();
+
+		ChatMember chatMember = optionalChatMember.get();
+		assertThat(chatMember.getChatRoom()).isEqualTo(chatRoom);
+		assertThat(chatMember.getUser()).isEqualTo(inviteUser);
+		assertThat(chatMember.getStatus()).isEqualTo(MemberStatus.JOINED);
+	}
+
+	@Test
+	@DisplayName("채팅방 탈퇴")
+	void leaveChatRoom() throws Exception {
+		// given
+		User user = createTestUser("dkdlsa");
+		ChatRoom chatRoom = createTestChatRoom(List.of(user));
+
+		// when
+		mockMvc.perform(delete("/api/v1/chatroom/{roomId}/members/me", chatRoom.getId())
+						.header(HttpHeaders.AUTHORIZATION, "Bearer " + jwtUtil.generateToken(user)))
+				.andExpect(status().isNoContent())
+				.andDo(print())
+				.andReturn();
+
+		// then
+		Optional<ChatMember> optionalChatMember = chatMemberRepository.findByUserAndChatRoom(user, chatRoom);
+		assertThat(optionalChatMember).isPresent();
+
+		ChatMember chatMember = optionalChatMember.get();
+		assertThat(chatMember.getChatRoom()).isEqualTo(chatRoom);
+		assertThat(chatMember.getUser()).isEqualTo(user);
+		assertThat(chatMember.getStatus()).isEqualTo(MemberStatus.LEFT);
+	}
+
+}

--- a/back/src/test/java/dev/kyudong/back/chat/member/ChatMemberServiceTests.java
+++ b/back/src/test/java/dev/kyudong/back/chat/member/ChatMemberServiceTests.java
@@ -1,0 +1,174 @@
+package dev.kyudong.back.chat.member;
+
+import dev.kyudong.back.chat.api.dto.event.ChatMemberInviteEvent;
+import dev.kyudong.back.chat.api.dto.req.ChatMemberInviteReqDto;
+import dev.kyudong.back.chat.domain.ChatMember;
+import dev.kyudong.back.chat.domain.ChatRoom;
+import dev.kyudong.back.chat.domain.MemberStatus;
+import dev.kyudong.back.chat.domain.RoomStatus;
+import dev.kyudong.back.chat.event.ChatEventHandler;
+import dev.kyudong.back.chat.exception.ChatMemberNotFoundException;
+import dev.kyudong.back.chat.repository.ChatMemberRepository;
+import dev.kyudong.back.chat.repository.ChatRoomRepository;
+import dev.kyudong.back.chat.service.ChatMemberService;
+import dev.kyudong.back.user.domain.User;
+import dev.kyudong.back.user.repository.UserRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.doNothing;
+
+@ExtendWith(MockitoExtension.class)
+public class ChatMemberServiceTests {
+
+	@Mock
+	private UserRepository userRepository;
+
+	@Mock
+	private ChatRoomRepository chatRoomRepository;
+
+	@Mock
+	private ChatMemberRepository chatMemberRepository;
+
+	@Mock
+	private ChatEventHandler chatEventHandler;
+
+	@InjectMocks
+	private ChatMemberService chatMemberService;
+
+	private static User makeMockUser(Long id) {
+		User mockUser = User.builder()
+				.username("mockUser")
+				.rawPassword("passWord")
+				.encodedPassword("passWord")
+				.build();
+		ReflectionTestUtils.setField(mockUser, "id", id);
+		return mockUser;
+	}
+
+	private static ChatRoom makeMockChatRoom(List<User> userList) {
+		ChatRoom mockChatRoom = ChatRoom.builder()
+				.initUserList(userList)
+				.build();
+		ReflectionTestUtils.setField(mockChatRoom, "id", 1L);
+		ReflectionTestUtils.setField(mockChatRoom, "createdAt", Instant.now());
+		return mockChatRoom;
+	}
+
+	@Test
+	@DisplayName("채팅방 초대 - 성공")
+	void inviteChatroom_succes() {
+		// given
+		User mockUser = makeMockUser(1L);
+		ChatRoom chatRoom = makeMockChatRoom(List.of(mockUser));
+		given(chatRoomRepository.findChatroomByIdAndStatus(anyLong(), any(RoomStatus.class)))
+				.willReturn(Optional.of(chatRoom));
+
+		Set<Long> existsUserIds = Set.of(mockUser.getId());
+		given(chatMemberRepository.findExistsMemberUserIds(
+				anySet(), any(ChatRoom.class), any(MemberStatus.class)
+		)).willReturn(existsUserIds);
+
+		User inviteUser = makeMockUser(2L);
+		given(userRepository.findByIdIn(anySet())).willReturn(List.of(inviteUser));
+
+		ChatMemberInviteReqDto requset = new ChatMemberInviteReqDto(Set.of(2L));
+		doNothing().when(chatEventHandler).handleMemberInvite(any(ChatMemberInviteEvent.class));
+
+		// when
+		chatMemberService.inviteChatRoom(mockUser.getId(), chatRoom.getId(), requset);
+
+		// then
+		then(chatRoomRepository).should().findChatroomByIdAndStatus(anyLong(), any(RoomStatus.class));
+		then(chatMemberRepository).should().findExistsMemberUserIds(anySet(), any(ChatRoom.class), any(MemberStatus.class));
+	}
+
+	@Test
+	@DisplayName("채팅방 초대 - 실패 : 채팅방에 없는 사용자가 초대")
+	void inviteChatroom_fail_memberNotFound() {
+		// given
+		User mockUser = makeMockUser(1L);
+		ChatRoom chatRoom = makeMockChatRoom(List.of(mockUser));
+		given(chatRoomRepository.findChatroomByIdAndStatus(anyLong(), any(RoomStatus.class)))
+				.willReturn(Optional.of(chatRoom));
+
+		Set<Long> existsUserIds = Set.of(9999L);
+		given(chatMemberRepository.findExistsMemberUserIds(
+				anySet(), any(ChatRoom.class), any(MemberStatus.class)
+		)).willReturn(existsUserIds);
+
+		ChatMemberInviteReqDto requset = new ChatMemberInviteReqDto(Set.of(2L));
+
+		// when
+		assertThatThrownBy(() -> chatMemberService.inviteChatRoom(mockUser.getId(), chatRoom.getId(), requset))
+				.isInstanceOf(ChatMemberNotFoundException.class);
+
+		// then
+		then(chatRoomRepository).should().findChatroomByIdAndStatus(anyLong(), any(RoomStatus.class));
+		then(chatMemberRepository).should().findExistsMemberUserIds(anySet(), any(ChatRoom.class), any(MemberStatus.class));
+	}
+
+	@Test
+	@DisplayName("채팅방 탈퇴 - 성공")
+	void leaveChatroom_succes() {
+		// given
+		User mockUser = makeMockUser(1L);
+		ChatRoom chatRoom = makeMockChatRoom(List.of(mockUser));
+		given(chatRoomRepository.findChatroomByIdAndStatus(anyLong(), any(RoomStatus.class)))
+				.willReturn(Optional.of(chatRoom));
+
+		final Long leaveUserId = mockUser.getId();
+		given(userRepository.getReferenceById(eq(leaveUserId))).willReturn(mockUser);
+
+		ChatMember mockMember = ChatMember.builder()
+				.user(mockUser)
+				.chatRoom(chatRoom)
+				.build();
+		given(chatMemberRepository.findByUserAndChatRoom(any(User.class), any(ChatRoom.class)))
+				.willReturn(Optional.of(mockMember));
+
+		// when
+		chatMemberService.leaveChatRoom(chatRoom.getId(), mockUser.getId());
+
+		// then
+		then(chatRoomRepository).should().findChatroomByIdAndStatus(anyLong(), any(RoomStatus.class));
+		then(chatMemberRepository).should().findByUserAndChatRoom(any(User.class), any(ChatRoom.class));
+		assertThat(mockMember.getStatus()).isEqualTo(MemberStatus.LEFT);
+	}
+
+	@Test
+	@DisplayName("채팅방 탈퇴 - 실패 : 채팅방에 없는 사용자가 초대")
+	void leaveChatroom_fail_memberNotFound() {
+		// given
+		User mockUser = makeMockUser(1L);
+		ChatRoom chatRoom = makeMockChatRoom(List.of(mockUser));
+		given(chatRoomRepository.findChatroomByIdAndStatus(anyLong(), any(RoomStatus.class)))
+				.willReturn(Optional.of(chatRoom));
+
+		given(chatMemberRepository.findExistsMemberUserIds(
+				anySet(), any(ChatRoom.class), any(MemberStatus.class)
+		)).willThrow(ChatMemberNotFoundException.class);
+
+		ChatMemberInviteReqDto requset = new ChatMemberInviteReqDto(Set.of(2L));
+
+		// when & then
+		assertThatThrownBy(() -> chatMemberService.inviteChatRoom(mockUser.getId(), chatRoom.getId(), requset))
+				.isInstanceOf(ChatMemberNotFoundException.class);
+	}
+
+}

--- a/back/src/test/java/dev/kyudong/back/chat/message/ChatMessageControllerTests.java
+++ b/back/src/test/java/dev/kyudong/back/chat/message/ChatMessageControllerTests.java
@@ -1,0 +1,179 @@
+package dev.kyudong.back.chat.message;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import dev.kyudong.back.chat.api.ChatMessageController;
+import dev.kyudong.back.chat.api.dto.req.ChatMessageCreateReqDto;
+import dev.kyudong.back.chat.api.dto.res.ChatMessageDetailResDto;
+import dev.kyudong.back.chat.api.dto.res.ChatMessageResDto;
+import dev.kyudong.back.chat.domain.*;
+import dev.kyudong.back.chat.exception.ChatMessageNotFoundException;
+import dev.kyudong.back.chat.exception.ChatRoomNotFoundException;
+import dev.kyudong.back.chat.service.ChatMessageService;
+import dev.kyudong.back.common.config.SecurityConfig;
+import dev.kyudong.back.common.jwt.JwtUtil;
+import dev.kyudong.back.security.WithMockCustomUser;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.MediaType;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.*;
+import static org.mockito.Mockito.doNothing;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(ChatMessageController.class)
+@Import(SecurityConfig.class)
+public class ChatMessageControllerTests {
+
+	@Autowired
+	private ObjectMapper objectMapper;
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@SuppressWarnings("unused")
+	@MockitoBean
+	private ChatMessageService chatMessageService;
+
+	@SuppressWarnings("unused")
+	@MockitoBean
+	private JwtUtil jwtUtil;
+
+	@SuppressWarnings("unused")
+	@MockitoBean
+	private UserDetailsService userDetailsService;
+
+	@Test
+	@DisplayName("채팅 메시지 목록 조회 - 성공")
+	@WithMockCustomUser(id = 999L)
+	void findMessagesApi_success() throws Exception {
+		// given
+		final Long roomId = 1L;
+		ChatMessageResDto response = new ChatMessageResDto(
+				roomId,
+				Instant.now(),
+				false,
+				List.of(
+						new ChatMessageDetailResDto(
+								1L, 
+								1L,
+								"안녕",
+								MessageType.TEXT,
+								MessageStatus.ACTIVE,
+								LocalDateTime.now()
+						),
+						new ChatMessageDetailResDto(
+								2L,
+								2L,
+								"그래 안녕",
+								MessageType.TEXT,
+								MessageStatus.ACTIVE,
+								LocalDateTime.now()
+						),
+						new ChatMessageDetailResDto(
+								3L,
+								1L,
+								"뭘봐",
+								MessageType.TEXT,
+								MessageStatus.ACTIVE,
+								LocalDateTime.now()
+						)
+				)
+		);
+		given(chatMessageService.findMessages(roomId, null, null)).willReturn(response);
+
+		// when & then
+		mockMvc.perform(get("/api/v1/chatroom/{roomId}/message", roomId))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.cursorId").value(roomId))
+				.andExpect(jsonPath("$.hasNext").value(false))
+				.andExpect(jsonPath("$.content").isArray())
+				.andDo(print());
+	}
+
+	@Test
+	@DisplayName("채팅 메시지 생성 - 성공")
+	@WithMockCustomUser(id = 999L)
+	void createMessageApi_success() throws Exception {
+		// given
+		final Long userId = 999L;
+		final Long roomId = 999L;
+		ChatMessageCreateReqDto request = new ChatMessageCreateReqDto("아아아아아아아ㅏ아앙", MessageType.TEXT);
+		doNothing().when(chatMessageService).createMessage(userId, roomId, request);
+
+		// when & then
+		mockMvc.perform(post("/api/v1/chatroom/{roomId}/message", roomId)
+						.contentType(MediaType.APPLICATION_JSON.toString())
+						.content(objectMapper.writeValueAsString(request)))
+				.andExpect(status().isNoContent())
+				.andDo(print());
+	}
+
+	@Test
+	@DisplayName("채팅방 생성 - 실패 : 채팅방이 존재하지 않음")
+	@WithMockCustomUser
+	void createMessageApi_fail_roomNotFound() throws Exception {
+		// given
+		final Long roomId = 999L;
+		ChatMessageCreateReqDto request = new ChatMessageCreateReqDto("아아아아아아아ㅏ아앙", MessageType.TEXT);
+
+		willThrow(new ChatRoomNotFoundException(roomId))
+				.given(chatMessageService)
+				.createMessage(anyLong(), eq(roomId), any(ChatMessageCreateReqDto.class));
+
+		// when & then
+		mockMvc.perform(post("/api/v1/chatroom/{roomId}/message", roomId)
+						.contentType(MediaType.APPLICATION_JSON.toString())
+						.content(objectMapper.writeValueAsString(request)))
+				.andExpect(status().isNotFound())
+				.andDo(print());
+	}
+
+	@Test
+	@DisplayName("채팅 메시지 삭제 - 성공")
+	@WithMockCustomUser(id = 999L)
+	void deleteMessageApi_success() throws Exception {
+		// given
+		final Long userId = 999L;
+		final Long roomId = 999L;
+		final Long messageId = 999L;
+		doNothing().when(chatMessageService).deleteMessage(userId, roomId, messageId);
+
+		// when & then
+		mockMvc.perform(delete("/api/v1/chatroom/{roomId}/message/{messageId}", roomId, messageId))
+				.andExpect(status().isNoContent())
+				.andDo(print());
+	}
+
+	@Test
+	@DisplayName("채팅방 생성 - 실패 : 삭제할 메시지가 없음")
+	@WithMockCustomUser
+	void deleteMessageApi_fail_messageNotFound() throws Exception {
+		// given
+		final Long roomId = 999L;
+		final Long messageId = 999L;
+		willThrow(new ChatMessageNotFoundException(messageId, roomId))
+				.given(chatMessageService)
+				.deleteMessage(anyLong(), eq(roomId), eq(messageId));
+
+		// when & then
+		mockMvc.perform(delete("/api/v1/chatroom/{roomId}/message/{messageId}", roomId, messageId))
+				.andExpect(status().isNotFound())
+				.andDo(print());
+	}
+
+}

--- a/back/src/test/java/dev/kyudong/back/chat/message/ChatMessageIntegrationTests.java
+++ b/back/src/test/java/dev/kyudong/back/chat/message/ChatMessageIntegrationTests.java
@@ -1,0 +1,251 @@
+package dev.kyudong.back.chat.message;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import dev.kyudong.back.chat.api.dto.event.ChatMessageCreateEvent;
+import dev.kyudong.back.chat.api.dto.event.ChatMessageDeleteEvent;
+import dev.kyudong.back.chat.api.dto.req.ChatMessageCreateReqDto;
+import dev.kyudong.back.chat.api.dto.res.ChatMessageResDto;
+import dev.kyudong.back.chat.domain.*;
+import dev.kyudong.back.chat.event.ChatEventHandler;
+import dev.kyudong.back.chat.repository.ChatMessageRepository;
+import dev.kyudong.back.chat.repository.ChatMemberRepository;
+import dev.kyudong.back.chat.repository.ChatRoomRepository;
+import dev.kyudong.back.common.jwt.JwtUtil;
+import dev.kyudong.back.user.domain.User;
+import dev.kyudong.back.user.repository.UserRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.MediaType;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpHeaders;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.Random;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.timeout;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.mockito.BDDMockito.then;
+
+@Transactional
+@SpringBootTest
+@AutoConfigureMockMvc
+public class ChatMessageIntegrationTests {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Autowired
+	private ObjectMapper objectMapper;
+
+	@Autowired
+	private UserRepository userRepository;
+
+	@Autowired
+	private ChatRoomRepository chatRoomRepository;
+
+	@Autowired
+	private ChatMemberRepository chatMemberRepository;
+
+	@Autowired
+	private ChatMessageRepository chatMessageRepository;
+
+	/**
+	 * 웹소켓 이벤트는 해당 테스트 클래스에서 다루지 않습니다
+	 */
+	@SuppressWarnings("unused")
+	@MockitoSpyBean
+	private ChatEventHandler chatEventHandler;
+
+	@Autowired
+	private JwtUtil jwtUtil;
+
+	private User createTestUser(String username) {
+		User newUser = User.builder()
+				.username(username)
+				.rawPassword("password")
+				.encodedPassword("password")
+				.build();
+		return userRepository.save(newUser);
+	}
+
+	private ChatRoom createTestChatRoom(List<User> userList) {
+		ChatRoom newChatRoom = ChatRoom.builder()
+				.initUserList(userList)
+				.build();
+		return chatRoomRepository.save(newChatRoom);
+	}
+
+	private void createTestChatMessages(List<ChatMessage> chatMessageList) {
+		chatMessageRepository.saveAll(chatMessageList);
+	}
+
+	@Test
+	@DisplayName("채팅 메시지 목록 조회")
+	void findMessages() throws Exception {
+		// given
+		User user1 = createTestUser("dkdlsa");
+		User user2 = createTestUser("zzqqcvvv");
+		List<User> userList = List.of(user1, user2);
+
+		ChatRoom chatRoom = createTestChatRoom(userList);
+		ChatMember member1 = chatMemberRepository.findByUserAndChatRoom(user1, chatRoom).orElseThrow();
+		ChatMember member2 = chatMemberRepository.findByUserAndChatRoom(user2, chatRoom).orElseThrow();
+
+		List<ChatMember> members = List.of(member1, member2);
+		Random random = new Random();
+
+		List<ChatMessage> chatMessageList = new ArrayList<>();
+		for (int i = 0; i < 100; i++) {
+			// 발신자 랜덤으로 진행
+			ChatMember randomSender = members.get(random.nextInt(members.size()));
+
+			ChatMessage chatMessage = ChatMessage.builder()
+					.sender(randomSender)
+					.content(randomSender.getUser().getUsername() + "가 보냄, 메시지 : " + i)
+					.messageType(MessageType.TEXT)
+					.build();
+			chatMessageList.add(chatMessage);
+			chatRoom.addMessage(chatMessage);
+		}
+		createTestChatMessages(chatMessageList);
+
+		// when
+		MvcResult result = mockMvc.perform(get("/api/v1/chatroom/{roomId}/message", chatRoom.getId())
+								.header(HttpHeaders.AUTHORIZATION, "Bearer " + jwtUtil.generateToken(user1)))
+						.andExpect(status().isOk())
+						.andDo(print())
+						.andReturn();
+
+		// then
+		String body = result.getResponse().getContentAsString();
+		ChatMessageResDto response = objectMapper.readValue(body, ChatMessageResDto.class);
+		assertThat(response).isNotNull();
+		assertThat(response.hasNext()).isTrue();
+	}
+
+	@Test
+	@DisplayName("채팅 메시지 목록 조회 - 커서로 조회")
+	void findMessages_withCurosr() throws Exception {
+		// given
+		User user1 = createTestUser("dkdlsa");
+		User user2 = createTestUser("zzqqcvvv");
+		List<User> userList = List.of(user1, user2);
+
+		ChatRoom chatRoom = createTestChatRoom(userList);
+		ChatMember member1 = chatMemberRepository.findByUserAndChatRoom(user1, chatRoom).orElseThrow();
+		ChatMember member2 = chatMemberRepository.findByUserAndChatRoom(user2, chatRoom).orElseThrow();
+
+		List<ChatMember> members = List.of(member1, member2);
+		Random random = new Random();
+
+		List<ChatMessage> chatMessageList = new ArrayList<>();
+		for (int i = 0; i < 100; i++) {
+			// 발신자 랜덤으로 진행
+			ChatMember randomSender = members.get(random.nextInt(members.size()));
+
+			ChatMessage chatMessage = ChatMessage.builder()
+					.sender(randomSender)
+					.content(randomSender.getUser().getUsername() + "가 보냄, 메시지 : " + i)
+					.messageType(MessageType.TEXT)
+					.build();
+			chatMessageList.add(chatMessage);
+			chatRoom.addMessage(chatMessage);
+		}
+		createTestChatMessages(chatMessageList);
+
+		final Long cursorId = chatMessageList.get(10).getId();
+		final Instant cursorTime = chatMessageList.get(10).getCreatedAt();
+
+		// when
+		MvcResult result = mockMvc.perform(get("/api/v1/chatroom/{roomId}/message", chatRoom.getId())
+						.header(HttpHeaders.AUTHORIZATION, "Bearer " + jwtUtil.generateToken(user1))
+						.param("cursorId", String.valueOf(cursorId))
+						.param("cursorTime", String.valueOf(cursorTime)))
+				.andExpect(status().isOk())
+				.andDo(print())
+				.andReturn();
+
+		// then
+		String body = result.getResponse().getContentAsString();
+		ChatMessageResDto response = objectMapper.readValue(body, ChatMessageResDto.class);
+		assertThat(response).isNotNull();
+		assertThat(response.hasNext()).isTrue();
+	}
+
+	@Test
+	@DisplayName("채팅 메시지 생성")
+	void createMessage() throws Exception {
+		// given
+		User user1 = createTestUser("dkdlsa");
+		User user2 = createTestUser("dfsxvzzc");
+		ChatMessageCreateReqDto request = new ChatMessageCreateReqDto(
+				"메시지 받아라!",
+				MessageType.TEXT
+		);
+		ChatRoom chatRoom = createTestChatRoom(List.of(user1, user2));
+
+		// when
+		mockMvc.perform(post("/api/v1/chatroom/{roomId}/message", chatRoom.getId())
+						.header(HttpHeaders.AUTHORIZATION, "Bearer " + jwtUtil.generateToken(user1))
+						.contentType(MediaType.APPLICATION_JSON.toString())
+						.content(objectMapper.writeValueAsString(request)))
+				.andExpect(status().isNoContent())
+				.andDo(print())
+				.andReturn();
+
+		// then
+		then(chatEventHandler).should(timeout(1000).times(1)).handleMessageCreate(any(ChatMessageCreateEvent.class));
+	}
+
+	@Test
+	@DisplayName("채팅 메시지 삭제")
+	void deleteMessage() throws Exception {
+		// given
+		User user1 = createTestUser("dkdlsa");
+		User user2 = createTestUser("dfsxvzzc");
+		ChatMessageCreateReqDto request = new ChatMessageCreateReqDto(
+				"메시지 받아라!",
+				MessageType.TEXT
+		);
+		ChatRoom chatRoom = createTestChatRoom(List.of(user1, user2));
+
+		ChatMember sender = chatMemberRepository.findByUserAndChatRoom(user1, chatRoom).orElseThrow();
+		ChatMessage newChatMessage = ChatMessage.builder()
+				.sender(sender)
+				.content("메시지 본문임다")
+				.messageType(MessageType.TEXT)
+				.build();
+		chatRoom.addMessage(newChatMessage);
+		ChatMessage savedChatMessage = chatMessageRepository.save(newChatMessage);
+
+		// when
+		mockMvc.perform(delete("/api/v1/chatroom/{roomId}/message/{messageId}", chatRoom.getId(), savedChatMessage.getId())
+						.header(HttpHeaders.AUTHORIZATION, "Bearer " + jwtUtil.generateToken(user1))
+						.contentType(MediaType.APPLICATION_JSON.toString())
+						.content(objectMapper.writeValueAsString(request)))
+				.andExpect(status().isNoContent())
+				.andDo(print())
+				.andReturn();
+
+		// then
+		then(chatEventHandler).should(timeout(1000).times(1)).handleMessageDelete(any(ChatMessageDeleteEvent.class));
+		Optional<ChatMessage> optionalChatMessage = chatMessageRepository.findById(savedChatMessage.getId());
+		assertThat(optionalChatMessage).isPresent();
+		assertThat(optionalChatMessage.get().getMessageStatus()).isEqualTo(MessageStatus.DELETED);
+	}
+
+
+}

--- a/back/src/test/java/dev/kyudong/back/chat/message/ChatMessageServiceTests.java
+++ b/back/src/test/java/dev/kyudong/back/chat/message/ChatMessageServiceTests.java
@@ -1,0 +1,333 @@
+package dev.kyudong.back.chat.message;
+
+import dev.kyudong.back.chat.api.dto.event.ChatMessageCreateEvent;
+import dev.kyudong.back.chat.api.dto.event.ChatMessageDeleteEvent;
+import dev.kyudong.back.chat.api.dto.req.ChatMessageCreateReqDto;
+import dev.kyudong.back.chat.api.dto.res.ChatMessageResDto;
+import dev.kyudong.back.chat.domain.ChatMember;
+import dev.kyudong.back.chat.domain.ChatMessage;
+import dev.kyudong.back.chat.domain.ChatRoom;
+import dev.kyudong.back.chat.domain.MessageType;
+import dev.kyudong.back.chat.event.ChatEventHandler;
+import dev.kyudong.back.chat.exception.ChatMessageNotFoundException;
+import dev.kyudong.back.chat.exception.ChatMemberNotFoundException;
+import dev.kyudong.back.chat.exception.ChatRoomNotFoundException;
+import dev.kyudong.back.chat.repository.ChatMessageRepository;
+import dev.kyudong.back.chat.repository.ChatMemberRepository;
+import dev.kyudong.back.chat.repository.ChatRoomRepository;
+import dev.kyudong.back.chat.service.ChatMessageService;
+import dev.kyudong.back.common.exception.InvalidAccessException;
+import dev.kyudong.back.user.domain.User;
+import dev.kyudong.back.user.repository.UserRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.never;
+
+@ExtendWith(MockitoExtension.class)
+public class ChatMessageServiceTests {
+
+	@Mock
+	private UserRepository userRepository;
+
+	@Mock
+	private ChatRoomRepository chatRoomRepository;
+
+	@Mock
+	private ChatMessageRepository chatMessageRepository;
+
+	@Mock
+	private ChatMemberRepository chatMemberRepository;
+
+	@Mock
+	private ChatEventHandler chatEventHandler;
+
+	@InjectMocks
+	private ChatMessageService chatMessageService;
+
+	private static User makeMockUser(String username, Long id) {
+		User mockUser = User.builder()
+				.username(username)
+				.rawPassword("passWord")
+				.encodedPassword("passWord")
+				.build();
+		ReflectionTestUtils.setField(mockUser, "id", id);
+		return mockUser;
+	}
+
+	private static ChatRoom makeMockChatRoom(List<User> userList) {
+		ChatRoom mockChatRoom = ChatRoom.builder()
+				.initUserList(userList)
+				.build();
+		ReflectionTestUtils.setField(mockChatRoom, "id", 1L);
+		return mockChatRoom;
+	}
+
+	private static ChatMember makeMockChatMember(User user) {
+		ChatMember mockChatMember = ChatMember.builder()
+				.user(user)
+				.build();
+		ReflectionTestUtils.setField(mockChatMember, "id", 1L);
+		return mockChatMember;
+	}
+
+	private static ChatMessage makeMockChatMessage(ChatMember sender, Long id) {
+		ChatMessage newChatMessage = ChatMessage.builder()
+				.sender(sender)
+				.content("본문")
+				.messageType(MessageType.TEXT)
+				.build();
+		ReflectionTestUtils.setField(newChatMessage, "id", id);
+		ReflectionTestUtils.setField(newChatMessage, "createdAt", Instant.now());
+		return newChatMessage;
+	}
+
+	@Test
+	@DisplayName("채팅방 참여 - 성공")
+	void inviteChatroom_success() {
+		// given
+		User mockUser1 = makeMockUser("zdfzdsf", 1L);
+		User mockUser2 = makeMockUser("ekcnvkzx", 2L);
+		given(userRepository.getReferenceById(anyLong())).willReturn(mockUser1);
+
+		ChatRoom mockChatRoom = makeMockChatRoom(List.of(mockUser1, mockUser2));
+		given(chatRoomRepository.findById(anyLong())).willReturn(Optional.of(mockChatRoom));
+
+		ChatMember mockChatMember = makeMockChatMember(mockUser1);
+		given(chatMemberRepository.findByUserAndChatRoom(any(User.class), any(ChatRoom.class)))
+				.willReturn(Optional.of(mockChatMember));
+
+		ChatMessage mockChatMessage = makeMockChatMessage(mockChatMember, 1L);
+		given(chatMessageRepository.save(any(ChatMessage.class))).willReturn(mockChatMessage);
+
+		ChatMessageCreateReqDto request = new ChatMessageCreateReqDto("본문", MessageType.TEXT);
+		doNothing().when(chatEventHandler).handleMessageCreate(any(ChatMessageCreateEvent.class));
+
+		// when
+		chatMessageService.createMessage(mockUser1.getId(), mockChatRoom.getId(), request);
+
+		// then
+		then(userRepository).should().getReferenceById(anyLong());
+		then(chatRoomRepository).should().findById(anyLong());
+		then(chatMemberRepository).should().findByUserAndChatRoom(any(User.class), any(ChatRoom.class));
+		then(chatMessageRepository).should().save(any(ChatMessage.class));
+	}
+
+	@Test
+	@DisplayName("채팅 메시지 생성 - 실패 : 채팅방이 존재하지 않음")
+	void createMessage_fail_chatRoomNotFound() {
+		// given
+		User mockUser1 = makeMockUser("zdfzdsf", 1L);
+		given(userRepository.getReferenceById(anyLong())).willReturn(mockUser1);
+
+		ChatRoom mockChatRoom = makeMockChatRoom(List.of(mockUser1));
+		given(chatRoomRepository.findById(anyLong())).willReturn(Optional.empty());
+
+		ChatMessageCreateReqDto request = new ChatMessageCreateReqDto("본문", MessageType.TEXT);
+
+		// when
+		assertThatThrownBy(() -> chatMessageService.createMessage(mockUser1.getId(), mockChatRoom.getId(), request))
+				.isInstanceOf(ChatRoomNotFoundException.class);
+
+		// then
+		then(userRepository).should().getReferenceById(anyLong());
+		then(chatRoomRepository).should().findById(anyLong());
+		then(chatMemberRepository).should(never()).findByUserAndChatRoom(any(User.class), any(ChatRoom.class));
+		then(chatMessageRepository).should(never()).save(any(ChatMessage.class));
+	}
+
+	@Test
+	@DisplayName("채팅 메시지 생성 - 실패 : 채팅 사용자가 방에 존재하지 않음")
+	void createMessage_fail_memberNotFound() {
+		// given
+		User mockUser1 = makeMockUser("zdfzdsf", 1L);
+		given(userRepository.getReferenceById(anyLong())).willReturn(mockUser1);
+
+		ChatRoom mockChatRoom = makeMockChatRoom(List.of(mockUser1));
+		given(chatRoomRepository.findById(anyLong())).willReturn(Optional.of(mockChatRoom));
+
+		given(chatMemberRepository.findByUserAndChatRoom(mockUser1, mockChatRoom))
+				.willReturn(Optional.empty());
+
+		ChatMessageCreateReqDto request = new ChatMessageCreateReqDto("본문", MessageType.TEXT);
+
+		// when
+		assertThatThrownBy(() -> chatMessageService.createMessage(mockUser1.getId(), mockChatRoom.getId(), request))
+				.isInstanceOf(ChatMemberNotFoundException.class);
+
+		// then
+		then(userRepository).should().getReferenceById(anyLong());
+		then(chatRoomRepository).should().findById(anyLong());
+		then(chatMemberRepository).should().findByUserAndChatRoom(any(User.class), any(ChatRoom.class));
+		then(chatMessageRepository).should(never()).save(any(ChatMessage.class));
+	}
+
+	@Test
+	@DisplayName("채팅 메시지 삭제 - 성공")
+	void deleteMessage_success() {
+		// given
+		User mockUser1 = makeMockUser("zdfzdsf", 1L);
+		User mockUser2 = makeMockUser("ekcnvkzx", 2L);
+		given(userRepository.getReferenceById(anyLong())).willReturn(mockUser1);
+
+		ChatRoom mockChatRoom = makeMockChatRoom(List.of(mockUser1, mockUser2));
+		given(chatRoomRepository.findById(anyLong())).willReturn(Optional.of(mockChatRoom));
+
+		ChatMember mockChatMember = makeMockChatMember(mockUser1);
+		given(chatMemberRepository.findByUserAndChatRoom(any(User.class), any(ChatRoom.class)))
+				.willReturn(Optional.of(mockChatMember));
+
+		ChatMessage mockChatMessage = makeMockChatMessage(mockChatMember, 1L);
+		ReflectionTestUtils.setField(mockChatMessage, "chatRoom", mockChatRoom);
+		given(chatMessageRepository
+				.findByIdAndChatRoomAndSender(anyLong(), any(ChatRoom.class), any(ChatMember.class)))
+				.willReturn(Optional.of(mockChatMessage));
+		doNothing().when(chatEventHandler).handleMessageDelete(any(ChatMessageDeleteEvent.class));
+
+		// when
+		chatMessageService.deleteMessage(mockUser1.getId(), mockChatRoom.getId(), mockChatMessage.getId());
+
+		// then
+		then(userRepository).should().getReferenceById(anyLong());
+		then(chatRoomRepository).should().findById(anyLong());
+		then(chatMemberRepository).should().findByUserAndChatRoom(any(User.class), any(ChatRoom.class));
+		then(chatMessageRepository).should()
+				.findByIdAndChatRoomAndSender(anyLong(), any(ChatRoom.class), any(ChatMember.class));
+	}
+
+	@Test
+	@DisplayName("채팅 메시지 삭제 - 실패 : 채팅방에 존재하지 메시지")
+	void deleteMessage_fail_chatMessageNotFound() {
+		// given
+		User mockUser1 = makeMockUser("zdfzdsf", 1L);
+		given(userRepository.getReferenceById(anyLong())).willReturn(mockUser1);
+
+		ChatRoom mockChatRoom = makeMockChatRoom(List.of(mockUser1));
+		given(chatRoomRepository.findById(anyLong())).willReturn(Optional.of(mockChatRoom));
+
+		ChatMember mockChatMember = makeMockChatMember(mockUser1);
+		given(chatMemberRepository.findByUserAndChatRoom(any(User.class), any(ChatRoom.class)))
+				.willReturn(Optional.of(mockChatMember));
+
+		given(chatMessageRepository.findByIdAndChatRoomAndSender(anyLong(), any(ChatRoom.class), any(ChatMember.class)))
+				.willThrow(ChatMessageNotFoundException.class);
+
+		// when
+		assertThatThrownBy(() -> chatMessageService.deleteMessage(mockUser1.getId(), mockChatRoom.getId(), 999L))
+				.isInstanceOf(ChatMessageNotFoundException.class);
+
+		// then
+		then(userRepository).should().getReferenceById(anyLong());
+		then(chatRoomRepository).should().findById(anyLong());
+		then(chatMemberRepository).should().findByUserAndChatRoom(any(User.class), any(ChatRoom.class));
+	}
+
+	@Test
+	@DisplayName("채팅 메시지 삭제 - 실패 : 메시지 삭제 권한 없음")
+	void deleteMessage_fail_invalidAccess() {
+		// given
+		User mockUser1 = makeMockUser("zdfzdsf", 1L);
+		User mockUser2 = makeMockUser("ekcnvkzx", 2L);
+		given(userRepository.getReferenceById(anyLong())).willReturn(mockUser1);
+
+		ChatRoom mockChatRoom = makeMockChatRoom(List.of(mockUser1, mockUser2));
+		given(chatRoomRepository.findById(anyLong())).willReturn(Optional.of(mockChatRoom));
+
+		ChatMember mockChatMember = makeMockChatMember(mockUser1);
+		given(chatMemberRepository.findByUserAndChatRoom(any(User.class), any(ChatRoom.class)))
+				.willReturn(Optional.of(mockChatMember));
+
+		ChatMessage mockChatMessage = makeMockChatMessage(mockChatMember, 1L);
+		ReflectionTestUtils.setField(mockChatMessage, "chatRoom", mockChatRoom);
+		given(chatMessageRepository
+				.findByIdAndChatRoomAndSender(anyLong(), any(ChatRoom.class), any(ChatMember.class)))
+				.willReturn(Optional.of(mockChatMessage));
+
+		// when
+		assertThatThrownBy(() -> chatMessageService.deleteMessage(mockUser2.getId(), mockChatRoom.getId(), mockChatMessage.getId()))
+				.isInstanceOf(InvalidAccessException.class);
+
+		// then
+		then(userRepository).should().getReferenceById(anyLong());
+		then(chatRoomRepository).should().findById(anyLong());
+		then(chatMemberRepository).should().findByUserAndChatRoom(any(User.class), any(ChatRoom.class));
+	}
+
+	@Test
+	@DisplayName("채팅 메시지 조회 - 성공")
+	void findChatMessage_success() {
+		// given
+		final Long roomId = 1L;
+		User mockUser = makeMockUser("axzczxcdn", 1L);
+		ChatMember mockChatMember = makeMockChatMember(mockUser);
+		ChatMessage mockChatMessage = makeMockChatMessage(mockChatMember, 1L);
+		Slice<ChatMessage> chatMessages = new SliceImpl<>(List.of(mockChatMessage));
+		given(chatMessageRepository.findChatMessage(anyLong(), any(PageRequest.class)))
+				.willReturn(chatMessages);
+
+		// when
+		ChatMessageResDto response = chatMessageService.findMessages(roomId, null, null);
+
+		// then
+		assertThat(response).isNotNull();
+		assertThat(response.hasNext()).isFalse();
+		assertThat(response.cursorId()).isNull();
+		assertThat(response.cursorTime()).isNull();
+		then(chatMessageRepository)
+				.should().findChatMessage(anyLong(), any(PageRequest.class));
+		then(chatMessageRepository).should(never())
+				.findChatMessageByCursorTime(anyLong(), anyLong(), any(Instant.class), any(PageRequest.class));
+	}
+
+	@Test
+	@DisplayName("채팅 메시지 조회 - 성공 : 커서를 이용")
+	void findChatMessage_success_withCursor() {
+		// given
+		final Long roomId = 1L;
+		User mockUser = makeMockUser("axzczxcdn", 1L);
+		ChatMember mockChatMember = makeMockChatMember(mockUser);
+		ChatMessage mockChatMessage1 = makeMockChatMessage(mockChatMember, 1L);
+		ChatMessage mockChatMessage2 = makeMockChatMessage(mockChatMember, 2L);
+		ChatMessage mockChatMessage3 = makeMockChatMessage(mockChatMember, 3L);
+		Slice<ChatMessage> chatMessages = new SliceImpl<>(
+				List.of(mockChatMessage1, mockChatMessage2, mockChatMessage3),
+				PageRequest.of(0, 10),
+				true
+		);
+		given(chatMessageRepository.findChatMessage(anyLong(), any(PageRequest.class)))
+				.willReturn(chatMessages);
+
+		// when
+		ChatMessageResDto response = chatMessageService.findMessages(roomId, null, null);
+
+		// then
+		assertThat(response).isNotNull();
+		assertThat(response.hasNext()).isTrue();
+		assertThat(response.cursorId()).isNotNull();
+		assertThat(response.cursorTime()).isNotNull();
+		then(chatMessageRepository)
+				.should().findChatMessage(anyLong(), any(PageRequest.class));
+		then(chatMessageRepository).should(never())
+				.findChatMessageByCursorTime(anyLong(), anyLong(), any(Instant.class), any(PageRequest.class));
+	}
+
+}

--- a/back/src/test/java/dev/kyudong/back/chat/room/ChatRoomControllerTests.java
+++ b/back/src/test/java/dev/kyudong/back/chat/room/ChatRoomControllerTests.java
@@ -1,0 +1,136 @@
+package dev.kyudong.back.chat.room;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import dev.kyudong.back.chat.api.ChatRoomController;
+import dev.kyudong.back.chat.api.dto.req.ChatRoomCreateReqDto;
+import dev.kyudong.back.chat.api.dto.res.ChatRoomCreateResDto;
+import dev.kyudong.back.chat.api.dto.res.ChatRoomDetailResDto;
+import dev.kyudong.back.chat.api.dto.res.ChatRoomResDto;
+import dev.kyudong.back.chat.domain.RoomStatus;
+import dev.kyudong.back.chat.service.ChatRoomService;
+import dev.kyudong.back.common.config.SecurityConfig;
+import dev.kyudong.back.common.jwt.JwtUtil;
+import dev.kyudong.back.security.WithMockCustomUser;
+import dev.kyudong.back.user.exception.UsersNotFoundException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.MediaType;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Set;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(ChatRoomController.class)
+@Import(SecurityConfig.class)
+public class ChatRoomControllerTests {
+
+	@Autowired
+	private ObjectMapper objectMapper;
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@SuppressWarnings("unused")
+	@MockitoBean
+	private ChatRoomService chatRoomService;
+
+	@SuppressWarnings("unused")
+	@MockitoBean
+	private JwtUtil jwtUtil;
+
+	@SuppressWarnings("unused")
+	@MockitoBean
+	private UserDetailsService userDetailsService;
+
+	@Test
+	@DisplayName("채팅방 목록 조회 - 성공")
+	@WithMockCustomUser(id = 999L)
+	void findChatroomsApi_success() throws Exception {
+		// given
+		final Long userId = 999L;
+		ChatRoomResDto response = new ChatRoomResDto(
+				1L,
+				Instant.now(),
+				false,
+				List.of(
+						new ChatRoomDetailResDto(1L, 2),
+						new ChatRoomDetailResDto(2L, 10),
+						new ChatRoomDetailResDto(3L, 22)
+				)
+		);
+		given(chatRoomService.findChatRooms(userId, null, null)).willReturn(response);
+
+		// when & then
+		mockMvc.perform(get("/api/v1/chatroom"))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.lastChatroomId").value(1L))
+				.andExpect(jsonPath("$.hasNext").value(false))
+				.andExpect(jsonPath("$.content").isArray())
+				.andDo(print());
+		then(chatRoomService).should().findChatRooms(userId, null, null);
+	}
+
+	@Test
+	@DisplayName("채팅방 생성 - 성공")
+	@WithMockCustomUser(id = 999L)
+	void createChatRoomApi_success() throws Exception {
+		// given
+		final Long userId = 999L;
+		ChatRoomCreateReqDto request = new ChatRoomCreateReqDto(
+				"myRoom!",
+				Set.of(1L, 2L, 3L)
+		);
+
+		ChatRoomCreateResDto chatroomCreateResDto = new ChatRoomCreateResDto(
+				1L, 3, RoomStatus.ACTIVE, LocalDateTime.now()
+		);
+		given(chatRoomService.createChatRoom(userId, request)).willReturn(chatroomCreateResDto);
+
+		// when & then
+		mockMvc.perform(post("/api/v1/chatroom")
+						.contentType(MediaType.APPLICATION_JSON.toString())
+						.content(objectMapper.writeValueAsString(request)))
+				.andExpect(status().isCreated())
+				.andExpect(jsonPath("$.roomId").value(1L))
+				.andExpect(jsonPath("$.memberCount").value(3))
+				.andDo(print());
+		then(chatRoomService).should().createChatRoom(userId, request);
+	}
+
+	@Test
+	@DisplayName("채팅방 생성 - 실패 : 사용자들이 조회가 안됨")
+	@WithMockCustomUser(id = 999L)
+	void createChatRoomApi_fail_usersNotFound() throws Exception {
+		// given
+		final Long userId = 999L;
+		ChatRoomCreateReqDto request = new ChatRoomCreateReqDto(
+				"myRoom!",
+				Set.of(1L, 2L, 3L)
+		);
+
+		given(chatRoomService.createChatRoom(userId, request)).willThrow(UsersNotFoundException.class);
+
+		// when & then
+		mockMvc.perform(post("/api/v1/chatroom")
+						.contentType(MediaType.APPLICATION_JSON.toString())
+						.content(objectMapper.writeValueAsString(request)))
+				.andExpect(status().isNotFound())
+				.andDo(print());
+	}
+
+}

--- a/back/src/test/java/dev/kyudong/back/chat/room/ChatRoomIntegrationTests.java
+++ b/back/src/test/java/dev/kyudong/back/chat/room/ChatRoomIntegrationTests.java
@@ -1,0 +1,113 @@
+package dev.kyudong.back.chat.room;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import dev.kyudong.back.chat.api.dto.req.ChatRoomCreateReqDto;
+import dev.kyudong.back.chat.api.dto.res.ChatRoomCreateResDto;
+import dev.kyudong.back.chat.api.dto.res.ChatRoomResDto;
+import dev.kyudong.back.chat.domain.ChatRoom;
+import dev.kyudong.back.chat.repository.ChatRoomRepository;
+import dev.kyudong.back.common.jwt.JwtUtil;
+import dev.kyudong.back.user.domain.User;
+import dev.kyudong.back.user.repository.UserRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.MediaType;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpHeaders;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Set;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.assertj.core.api.Assertions.*;
+
+@Transactional
+@SpringBootTest
+@AutoConfigureMockMvc
+public class ChatRoomIntegrationTests {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Autowired
+	private ObjectMapper objectMapper;
+
+	@Autowired
+	private UserRepository userRepository;
+
+	@Autowired
+	private ChatRoomRepository chatRoomRepository;
+
+	@Autowired
+	private JwtUtil jwtUtil;
+
+	private User createTestUser(String username) {
+		User newUser = User.builder()
+				.username(username)
+				.rawPassword("password")
+				.encodedPassword("password")
+				.build();
+		return userRepository.save(newUser);
+	}
+
+	@Test
+	@DisplayName("채팅방 목록 조회")
+	void findChatRooms() throws Exception {
+		// given
+		User user1 = createTestUser("dkdlsa");
+		User user2 = createTestUser("zzqqcvvv");
+		ChatRoom newChatRoom = ChatRoom.builder()
+				.initUserList(List.of(user1, user2))
+				.build();
+		chatRoomRepository.save(newChatRoom);
+
+		// when
+		MvcResult result = mockMvc.perform(get("/api/v1/chatroom")
+								.header(HttpHeaders.AUTHORIZATION, "Bearer " + jwtUtil.generateToken(user1)))
+						.andExpect(status().isOk())
+						.andDo(print())
+						.andReturn();
+
+		// then
+		String body = result.getResponse().getContentAsString();
+		ChatRoomResDto response = objectMapper.readValue(body, ChatRoomResDto.class);
+		assertThat(response).isNotNull();
+	}
+
+	@Test
+	@DisplayName("채팅방 생성")
+	void createChatRoom() throws Exception {
+		// given
+		User user1 = createTestUser("dkdlsa");
+		User user2 = createTestUser("dfsxvzzc");
+		ChatRoomCreateReqDto request = new ChatRoomCreateReqDto(
+				"myRoom!",
+				Set.of(user1.getId(), user2.getId())
+		);
+
+		// when
+		MvcResult result = mockMvc.perform(post("/api/v1/chatroom")
+								.header(HttpHeaders.AUTHORIZATION, "Bearer " + jwtUtil.generateToken(user1))
+								.contentType(MediaType.APPLICATION_JSON.toString())
+								.content(objectMapper.writeValueAsString(request)))
+						.andExpect(status().isCreated())
+						.andExpect(header().exists("Location"))
+						.andDo(print())
+						.andReturn();
+
+		// then
+		String body = result.getResponse().getContentAsString();
+		ChatRoomCreateResDto response = objectMapper.readValue(body, ChatRoomCreateResDto.class);
+		assertThat(response).isNotNull();
+	}
+
+}

--- a/back/src/test/java/dev/kyudong/back/chat/room/ChatRoomServiceTests.java
+++ b/back/src/test/java/dev/kyudong/back/chat/room/ChatRoomServiceTests.java
@@ -1,0 +1,151 @@
+package dev.kyudong.back.chat.room;
+
+import dev.kyudong.back.chat.api.dto.event.ChatRoomCreateEvent;
+import dev.kyudong.back.chat.api.dto.req.ChatRoomCreateReqDto;
+import dev.kyudong.back.chat.api.dto.res.ChatRoomCreateResDto;
+import dev.kyudong.back.chat.api.dto.res.ChatRoomResDto;
+import dev.kyudong.back.chat.domain.ChatRoom;
+import dev.kyudong.back.chat.domain.RoomStatus;
+import dev.kyudong.back.chat.event.ChatEventHandler;
+import dev.kyudong.back.chat.repository.ChatRoomRepository;
+import dev.kyudong.back.chat.service.ChatRoomService;
+import dev.kyudong.back.user.domain.User;
+import dev.kyudong.back.user.exception.UsersNotFoundException;
+import dev.kyudong.back.user.repository.UserRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.doNothing;
+
+@ExtendWith(MockitoExtension.class)
+public class ChatRoomServiceTests {
+
+	@Mock
+	private UserRepository userRepository;
+
+	@Mock
+	private ChatRoomRepository chatRoomRepository;
+
+	@Mock
+	private ChatEventHandler chatEventHandler;
+
+	@InjectMocks
+	private ChatRoomService chatRoomService;
+
+	private static User makeMockUser(String username, Long id) {
+		User mockUser = User.builder()
+				.username(username)
+				.rawPassword("passWord")
+				.encodedPassword("passWord")
+				.build();
+		ReflectionTestUtils.setField(mockUser, "id", id);
+		return mockUser;
+	}
+
+	private static ChatRoom makeMockChatRoom(List<User> userList) {
+		ChatRoom mockChatRoom = ChatRoom.builder()
+				.initUserList(userList)
+				.build();
+		ReflectionTestUtils.setField(mockChatRoom, "id", 1L);
+		ReflectionTestUtils.setField(mockChatRoom, "createdAt", Instant.now());
+		return mockChatRoom;
+	}
+
+	@Test
+	@DisplayName("채팅방 조회 - 성공")
+	void findChatrooms_succes() {
+		// given
+		Long userId = 1L;
+		User mockUser = makeMockUser("dkxxz", userId);
+		given(userRepository.getReferenceById(anyLong())).willReturn(mockUser);
+
+		ChatRoom chatRoom1 = makeMockChatRoom(
+				List.of(
+						makeMockUser("zdsfzd", 9L)
+				)
+		);
+		ChatRoom chatRoom2 = makeMockChatRoom(
+				List.of(
+						makeMockUser("zzzz1dfbbv", 83L),
+						makeMockUser("z1fdvfv", 1283L),
+						makeMockUser("zzzz", 1111L)
+				)
+		);
+
+		PageRequest pageRequest = PageRequest.of(0, 10);
+		Slice<ChatRoom> chatrooms = new SliceImpl<>(List.of(chatRoom1, chatRoom2), pageRequest, false);
+		given(chatRoomRepository.findChatRooomsByMember(mockUser, pageRequest))
+				.willReturn(chatrooms);
+
+		// when
+		ChatRoomResDto response = chatRoomService.findChatRooms(userId, null, null);
+
+		// then
+		assertThat(response).isNotNull();
+		assertThat(response.hasNext()).isFalse();
+		then(userRepository).should().getReferenceById(anyLong());
+		then(chatRoomRepository).should().findChatRooomsByMember(any(User.class), any(PageRequest.class));
+	}
+
+	@Test
+	@DisplayName("채팅룸 생성 - 성공")
+	void createChatRoom_success() {
+		// given
+		User mockUser1 = makeMockUser("cnzn1d", 1L);
+		User mockUser2 = makeMockUser("zzsda", 2L);
+
+		ChatRoomCreateReqDto request = new ChatRoomCreateReqDto("hello", Set.of(1L, 2L));
+
+		List<User> userList = List.of(mockUser1, mockUser2);
+		given(userRepository.findByIdIn(request.userIds())).willReturn(userList);
+
+		ChatRoom chatRoom = makeMockChatRoom(userList);
+		given(chatRoomRepository.save(any(ChatRoom.class))).willReturn(chatRoom);
+
+		doNothing().when(chatEventHandler).handleRoomCreate(any(ChatRoomCreateEvent.class));
+
+		// when
+		ChatRoomCreateResDto response = chatRoomService.createChatRoom(mockUser1.getId(), request);
+
+		// then
+		assertThat(response.memberCount()).isEqualTo(2);
+		assertThat(response.status()).isEqualTo(RoomStatus.ACTIVE);
+		then(userRepository).should().findByIdIn(request.userIds());
+		then(chatRoomRepository).should().save(any(ChatRoom.class));
+	}
+
+	@Test
+	@DisplayName("채팅룸 생성 - 실패 : 채팅방 사용자들 조회가 안됨")
+	void createChatRoom_fail_usersNotFound() {
+		// given
+		User mockUser = makeMockUser("cnzn1d", 1L);
+
+		ChatRoomCreateReqDto request = new ChatRoomCreateReqDto("hello", Set.of(1L, 2L));
+
+		given(userRepository.findByIdIn(Set.of(1L, 2L))).willReturn(new ArrayList<>());
+
+		// when & then
+		assertThatThrownBy(() -> chatRoomService.createChatRoom(mockUser.getId(), request))
+				.isInstanceOf(UsersNotFoundException.class);
+	}
+
+}

--- a/back/src/test/java/dev/kyudong/back/chat/ws/ChatWebSocketTests.java
+++ b/back/src/test/java/dev/kyudong/back/chat/ws/ChatWebSocketTests.java
@@ -1,0 +1,298 @@
+package dev.kyudong.back.chat.ws;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import dev.kyudong.back.chat.api.dto.event.*;
+import dev.kyudong.back.chat.api.dto.ws.*;
+import dev.kyudong.back.chat.domain.*;
+import dev.kyudong.back.chat.event.ChatEventHandler;
+import dev.kyudong.back.chat.event.ChatEventType;
+import dev.kyudong.back.chat.websocket.ChatWebSocketMessage;
+import dev.kyudong.back.chat.repository.ChatMessageRepository;
+import dev.kyudong.back.chat.repository.ChatMemberRepository;
+import dev.kyudong.back.chat.repository.ChatRoomRepository;
+import dev.kyudong.back.common.jwt.JwtUtil;
+import dev.kyudong.back.user.domain.User;
+import dev.kyudong.back.user.repository.UserRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.lang.NonNull;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.web.socket.TextMessage;
+import org.springframework.web.socket.WebSocketSession;
+import org.springframework.web.socket.client.standard.StandardWebSocketClient;
+import org.springframework.web.socket.handler.TextWebSocketHandler;
+
+import java.net.URI;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
+public class ChatWebSocketTests {
+
+	@LocalServerPort
+	private int port;
+
+	@Autowired
+	private ChatEventHandler chatEventHandler;
+
+	@Autowired
+	private UserRepository userRepository;
+
+	@Autowired
+	private ChatRoomRepository chatRoomRepository;
+
+	@Autowired
+	private ChatMemberRepository chatMemberRepository;
+
+	@Autowired
+	private ChatMessageRepository chatMessageRepository;
+
+	@Autowired
+	private ObjectMapper objectMapper;
+
+	@Autowired
+	private JwtUtil jwtUtil;
+
+	private User createTestUser() {
+		User newUser = User.builder()
+				.username(randomUsername())
+				.rawPassword("password")
+				.encodedPassword("password")
+				.build();
+		return userRepository.save(newUser);
+	}
+
+	private String randomUsername() {
+		int length = ThreadLocalRandom.current().nextInt(20) + 4;
+		StringBuilder username = new StringBuilder();
+		for (int i = 0; i < length; i++) {
+			char randomChar = (char) ('a' + (ThreadLocalRandom.current().nextInt(26)));
+			username.append(randomChar);
+		}
+		return username.toString();
+	}
+
+	private ChatRoom createTestChatRoom(List<User> userList) {
+		ChatRoom newChatRoom = ChatRoom.builder()
+				.initUserList(userList)
+				.build();
+		return chatRoomRepository.save(newChatRoom);
+	}
+
+	private ChatMessage createTestChatMessage(ChatMember sender, ChatRoom chatRoom) {
+		ChatMessage newChatMessage = ChatMessage.builder()
+				.sender(sender)
+				.content("안녕하세요")
+				.messageType(MessageType.TEXT)
+				.build();
+		chatRoom.addMessage(newChatMessage);
+		return chatMessageRepository.save(newChatMessage);
+	}
+
+	private Set<ChatMember> createTestChatMembers(ChatRoom chatRoom, List<User> userList) {
+		return chatRoom.addNewMember(userList);
+	}
+
+	private WebSocketSession connectWebSocketClient(String token, BlockingQueue<String> messageQueue) throws Exception {
+		URI uri = new URI("ws://localhost:" + port + "/ws/chat?token=" + token);
+
+		return new StandardWebSocketClient().execute(new TextWebSocketHandler() {
+			@Override
+			public void handleTextMessage(@NonNull WebSocketSession session, @NonNull TextMessage message) {
+				messageQueue.add(message.getPayload());
+			}
+		}, uri.toString()).get(1, TimeUnit.SECONDS);
+	}
+
+	@Test
+	@DisplayName("채팅 메시지 생성 - 채팅바의 사용자에게 메시지를 전송한다")
+	void handleMessageCreate() throws Exception {
+		// given
+		User userA = createTestUser();
+		User userB = createTestUser();
+		List<User> userList = List.of(userA, userB);
+		ChatRoom chatRoom = createTestChatRoom(userList);
+
+		BlockingQueue<String> messageQueueA = new LinkedBlockingQueue<>();
+		BlockingQueue<String> messageQueueB = new LinkedBlockingQueue<>();
+		WebSocketSession sessionA = connectWebSocketClient(jwtUtil.generateToken(userA), messageQueueA);
+		WebSocketSession sessionB = connectWebSocketClient(jwtUtil.generateToken(userB), messageQueueB);
+
+		// 이벤트 생성
+		ChatMember sender = chatMemberRepository.findByUserAndChatRoom(userA, chatRoom).orElseThrow();
+		ChatMessage chatMessage = createTestChatMessage(sender, chatRoom);
+		ChatMessageCreateEvent payload = ChatMessageCreateEvent.of(chatMessage, chatRoom, userA);
+
+		// when
+		chatEventHandler.handleMessageCreate(payload);
+
+		// then
+		String messageA = messageQueueA.poll(1, TimeUnit.SECONDS);
+		String messageB = messageQueueB.poll(1, TimeUnit.SECONDS);
+		assertThat(messageA).isNotNull();
+		assertThat(messageB).isNotNull();
+
+		// 메시지 검증
+		ChatWebSocketMessage<ChatNewMessageWsDto> receivedMessage = objectMapper.readValue(messageA, new TypeReference<>() {});
+		assertThat(receivedMessage.payload().messageId()).isEqualTo(chatMessage.getId());
+		assertThat(receivedMessage.payload().content()).isEqualTo(chatMessage.getContent());
+
+		sessionA.close();
+		sessionB.close();
+	}
+
+	@Test
+	@DisplayName("채팅 메시지 삭제 - 채팅바의 사용자에게 삭제된 메시지를 전송한다")
+	void handleMessageDelete() throws Exception {
+		// given
+		User userA = createTestUser();
+		User userB = createTestUser();
+		List<User> userList = List.of(userA, userB);
+		ChatRoom chatRoom = createTestChatRoom(userList);
+
+		BlockingQueue<String> messageQueueA = new LinkedBlockingQueue<>();
+		BlockingQueue<String> messageQueueB = new LinkedBlockingQueue<>();
+		WebSocketSession sessionA = connectWebSocketClient(jwtUtil.generateToken(userA), messageQueueA);
+		WebSocketSession sessionB = connectWebSocketClient(jwtUtil.generateToken(userB), messageQueueB);
+
+		// 이벤트 생성
+		ChatMember sender = chatMemberRepository.findByUserAndChatRoom(userA, chatRoom).orElseThrow();
+		ChatMessage chatMessage = createTestChatMessage(sender, chatRoom);
+		chatMessage.delete();
+		ChatMessageDeleteEvent payload = ChatMessageDeleteEvent.of(chatMessage, chatRoom, userA.getId());
+
+		// when
+		chatEventHandler.handleMessageDelete(payload);
+
+		// then
+		String messageA = messageQueueA.poll(1, TimeUnit.SECONDS);
+		String messageB = messageQueueB.poll(1, TimeUnit.SECONDS);
+		assertThat(messageA).isNotNull();
+		assertThat(messageB).isNotNull();
+
+		// 메시지 검증
+		ChatWebSocketMessage<ChatDelMessageWsDto> receivedMessage = objectMapper.readValue(messageA, new TypeReference<>() {});
+		assertThat(receivedMessage.payload().messageId()).isEqualTo(chatMessage.getId());
+		assertThat(receivedMessage.payload().messageStatus()).isEqualTo(MessageStatus.DELETED);
+
+		sessionA.close();
+		sessionB.close();
+	}
+
+	@Test
+	@DisplayName("채팅방 생성 - 채팅방을 생성하고 방에 대한 메시지를 전송한다")
+	void handleRoomCreate() throws Exception {
+		// given
+		User userA = createTestUser();
+		User userB = createTestUser();
+		List<User> userList = List.of(userA, userB);
+		ChatRoom chatRoom = createTestChatRoom(userList);
+
+		BlockingQueue<String> messageQueueA = new LinkedBlockingQueue<>();
+		BlockingQueue<String> messageQueueB = new LinkedBlockingQueue<>();
+		WebSocketSession sessionA = connectWebSocketClient(jwtUtil.generateToken(userA), messageQueueA);
+		WebSocketSession sessionB = connectWebSocketClient(jwtUtil.generateToken(userB), messageQueueB);
+
+		// 이벤트 생성
+		ChatRoomCreateEvent payload = ChatRoomCreateEvent.from(chatRoom);
+
+		// when
+		chatEventHandler.handleRoomCreate(payload);
+
+		// then
+		String messageA = messageQueueA.poll(1, TimeUnit.SECONDS);
+		String messageB = messageQueueB.poll(1, TimeUnit.SECONDS);
+		assertThat(messageA).isNotNull();
+		assertThat(messageB).isNotNull();
+
+		sessionA.close();
+		sessionB.close();
+	}
+
+	@Test
+	@DisplayName("채팅방 초대 - 채팅방에 사용자를 초대한다")
+	void handleMemberInvite() throws Exception {
+		// given
+		User chatMember = createTestUser();
+		User inviteUser = createTestUser();
+		ChatRoom chatRoom = createTestChatRoom(List.of(chatMember));
+
+		BlockingQueue<String> messageQueueA = new LinkedBlockingQueue<>();
+		BlockingQueue<String> messageQueueB = new LinkedBlockingQueue<>();
+		WebSocketSession sessionA = connectWebSocketClient(jwtUtil.generateToken(chatMember), messageQueueA);
+		WebSocketSession sessionB = connectWebSocketClient(jwtUtil.generateToken(inviteUser), messageQueueB);
+
+		// 이벤트 생성
+		Set<ChatMember> newMembers = createTestChatMembers(
+				chatRoom,
+				List.of(
+					inviteUser,
+					createTestUser(),
+					createTestUser(),
+					createTestUser()
+				)
+		);
+		ChatMemberInviteEvent event = ChatMemberInviteEvent.of(chatRoom, Set.of(chatMember.getId()), newMembers);
+
+		// when
+		chatEventHandler.handleMemberInvite(event);
+
+		// then
+		String messageA = messageQueueA.poll(1, TimeUnit.SECONDS);
+		assertThat(messageA).isNotNull();
+		ChatWebSocketMessage<ChatNewMemberWsDto> newMemberMessage = objectMapper.readValue(messageA, new TypeReference<>() {});
+		assertThat(newMemberMessage.type()).isEqualTo(ChatEventType.NEW_MEMBER);
+
+		String messageB = messageQueueB.poll(1, TimeUnit.SECONDS);
+		assertThat(messageB).isNotNull();
+		ChatWebSocketMessage<ChatMemberInviteWsDto> inviteMemberMessage = objectMapper.readValue(messageB, new TypeReference<>() {});
+		assertThat(inviteMemberMessage.type()).isEqualTo(ChatEventType.INVITE_NEW_MEMBER);
+
+		sessionA.close();
+		sessionB.close();
+	}
+
+	@Test
+	@DisplayName("채팅방 탈퇴 - 사용자가 채팅방을 탈퇴한다")
+	void handleMemberLeft() throws Exception {
+		// given
+		User chatMember = createTestUser();
+		User leaveUser = createTestUser();
+		ChatRoom chatRoom = createTestChatRoom(List.of(chatMember, leaveUser));
+
+		BlockingQueue<String> messageQueueA = new LinkedBlockingQueue<>();
+		BlockingQueue<String> messageQueueB = new LinkedBlockingQueue<>();
+		WebSocketSession sessionA = connectWebSocketClient(jwtUtil.generateToken(chatMember), messageQueueA);
+		WebSocketSession sessionB = connectWebSocketClient(jwtUtil.generateToken(leaveUser), messageQueueB);
+
+		// 이벤트 생성
+		ChatMemberLeftEvent event = ChatMemberLeftEvent.of(chatRoom.getId(), leaveUser.getId(), chatRoom.getChatMembers());
+
+		// when
+		chatEventHandler.handleMemberLeft(event);
+
+		// then
+		String messageA = messageQueueA.poll(1, TimeUnit.SECONDS);
+		assertThat(messageA).isNotNull();
+		ChatWebSocketMessage<ChatMemberLeftWsDto> newMemberMessage = objectMapper.readValue(messageA, new TypeReference<>() {});
+		assertThat(newMemberMessage.type()).isEqualTo(ChatEventType.LEFT_MEMBER);
+
+		String messageB = messageQueueB.poll(1, TimeUnit.SECONDS);
+		assertThat(messageB).isNull();
+
+		sessionA.close();
+		sessionB.close();
+	}
+
+}

--- a/back/src/test/java/dev/kyudong/back/notification/NotificationEventHandlerTests.java
+++ b/back/src/test/java/dev/kyudong/back/notification/NotificationEventHandlerTests.java
@@ -116,7 +116,7 @@ public class NotificationEventHandlerTests {
 		then(followRepository).should().findByFollowingWithFollower(mockFollowing);
 		then(notificationRepository).should().saveAll(anyList());
 		then(notificationWebSocketHandler).should(times(mockFollows.size()))
-				.sendMessageToUser(anyLong(), any(NotificationDetailResDto.class));
+				.sendNotificationToUser(anyLong(), any(NotificationDetailResDto.class));
 	}
 
 }


### PR DESCRIPTION
Chat:
- Chat 엔티티와 Controller, Service 등 기본 골격 구현
- 관련 단위 테스트 및 통합 테스트 코드 작성
- 채팅 관련 CRUD API 엔드포인트 추가
- 채팅 관련 Exception 추가
- 웹 소켓과 관련 이벤트 및 클래스 추가

Notification:
- 웹 소켓 클래스 분리로 리팩토링

User:
- 채팅 사용자 중복 방지를 위해 hashCode와 equals 추가
- 사용자 목록 예외 클래스 추가
- 사용자 아이디 목록 조회 쿼리 추가

Post:
- h2 호환성을 위해 @Lob 컬럼에 columnDefinition 추가

Common:
- 테스트를 위한 h2 의존성 추가
- application.yml dev, test로 분리